### PR TITLE
Adding support for H6055

### DIFF
--- a/custom_components/govee-ble-lights/jsons/H6055.json
+++ b/custom_components/govee-ble-lights/jsons/H6055.json
@@ -1,0 +1,8 @@
+{
+    "message": "success",
+    "status": 200,
+    "data": {
+        "categories": [],
+        "supportSpeed": 0
+    }
+}

--- a/custom_components/govee-ble-lights/light.py
+++ b/custom_components/govee-ble-lights/light.py
@@ -28,6 +28,7 @@ _LOGGER = logging.getLogger(__name__)
 UUID_CONTROL_CHARACTERISTIC = '00010203-0405-0607-0809-0a0b0c0d2b11'
 EFFECT_PARSE = re.compile("\[(\d+)/(\d+)/(\d+)/(\d+)]")
 SEGMENTED_MODELS = ['H6053', 'H6072', 'H6102', 'H6199']
+ALT_MANUAL_CMD_MODELS = ['H6055']
 
 class LedCommand(IntEnum):
     """ A control command packet's type. """
@@ -43,6 +44,7 @@ class LedMode(IntEnum):
     Currently only manual is supported.
     """
     MANUAL = 0x02
+    ALT_MANUAL = 0x0D
     MICROPHONE = 0x06
     SCENES = 0x05
     SEGMENTS = 0x15
@@ -246,7 +248,11 @@ class GoveeBluetoothLight(LightEntity):
                                                               [LedMode.SEGMENTS, 0x01, red, green, blue, 0x00, 0x00, 0x00,
                                                                0x00, 0x00, 0xFF, 0x7F]))
             else:
-                commands.append(self._prepareSinglePacketData(LedCommand.COLOR, [LedMode.MANUAL, red, green, blue]))
+                if self._model in ALT_MANUAL_CMD_MODELS:
+                    commands.append(self._prepareSinglePacketData(LedCommand.COLOR, [LedMode.ALT_MANUAL, red, green, blue]))
+                else:    
+                    commands.append(self._prepareSinglePacketData(LedCommand.COLOR, [LedMode.MANUAL, red, green, blue]))
+                    
         if ATTR_EFFECT in kwargs:
             effect = kwargs.get(ATTR_EFFECT)
             if len(effect) > 0:


### PR DESCRIPTION
Adds support for H6055. Both H6055 and [H6005 from the looks of it](https://github.com/jonahclarsen/bluetooth_lights_controller/blob/3d5293532ebd73efaa08c393751b544073079a3c/bluetooth_lights_controller/bluetooth_led.py#L31) use 0x0D for manual mode so there's likely other models that do too.