### PR TITLE
Fix H617C and segmented models support

### DIFF
--- a/custom_components/govee-ble-lights/light.py
+++ b/custom_components/govee-ble-lights/light.py
@@ -293,8 +293,12 @@ class GoveeBluetoothLight(LightEntity):
         red, green, blue = rgb_color
 
         if self._is_segmented:
-            # H617C and similar: brightness command doesn't work reliably
-            # Instead, scale RGB values by brightness
+            # H617C and similar: set device brightness to MAX first
+            # This ensures the hardware brightness is at 100%, then we use RGB scaling
+            max_brightness_cmd = self._prepareSinglePacketData(LedCommand.BRIGHTNESS, [0xFE])
+            commands.extend([max_brightness_cmd, max_brightness_cmd, max_brightness_cmd])
+
+            # Use RGB scaling for actual brightness control
             # Minimum brightness ~10% to preserve color visibility
             min_brightness = 25  # ~10% of 255
             effective_brightness = max(min_brightness, brightness)


### PR DESCRIPTION
## Summary
Fixes support for H617C and other segmented LED strip models (H617x series).

## Problem
- H617C could not change colors properly
- Brightness was inverted (100% dimmer than 35%)
- On/off commands were unreliable
- Effects did not work

## Solution
- Add H617C and related models to SEGMENTED_MODELS list
- Use segment mode 0x15 for color commands on H617x series
- Send commands 3x with delays for BLE reliability
- Scale RGB values for brightness (brightness command unreliable on these models)
- Use simple scene codes for effects instead of multi-packet protocol
- Add retry logic to _connectBluetooth() for more reliable connections

## Testing
Tested on physical H617C device:
- ✅ Power on/off (reliable with 3x sends)
- ✅ All RGB colors working correctly
- ✅ Brightness control via RGB scaling (10-100%)
- ✅ Built-in scene effects working

## Models Affected
- H617A, H617C, H617E, H617F
- H6171, H6172, H6173
- H6053, H6072, H6102, H6199 (existing segmented models)

## Technical Details
- Commands need to be sent 3x with ~150ms delays for reliable BLE communication
- Brightness command (0x04) doesn't work reliably on H617x; using RGB value scaling instead
- Segment mode 0x15 format: `[0x15, 0x01, R, G, B, 0, 0, 0, 0, 0, 0xFF, 0x7F]`
- Effects use simple scene codes via mode 0x04 instead of multi-packet 0xa3 protocol