### PR TITLE
H617A dynamic scenes over BLE + BLE transport hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,15 +65,34 @@ Home Assistant effect dropdown.
   shared adapter; `available` reflects the BT stack; state survives restarts via
   `RestoreEntity`. Effect names are rendered readably (`Category - Scene`).
 
-### Known limitations
+### Scene speed control
 
-- **Scene speed** is intrinsic to each scene's payload and is not yet adjustable;
-  most scenes therefore play faster than the app default. The separate BLE speed
-  command has not been identified (it is **not** a trailing byte on the activate
-  packet).
-- A small number of scenes whose intrinsic speed is ~0 load correct colours but
-  appear static (e.g. `Festival - Carnival`) — likely the same missing speed
-  command.
+There is **no separate BLE "speed" command**. The Govee app sets a scene's speed
+by *rewriting bytes inside the `scenceParam` blob* before uploading it: it decodes
+the effect segments and overwrites their colour/move/brightness timing fields with
+values drawn from the scene's own `speedInfo` lookup table at a chosen index. This
+fork reproduces that rewrite (`govee_scene_speed.py`), so scene speed is adjustable
+from Home Assistant. The speed tables already live in the bundled catalogue, so no
+extra capture is needed; an unrecognised blob is uploaded untouched.
+
+Two entity services are exposed (target a Govee light entity):
+
+- **`govee-ble-lights.set_speed`** — set *this strip's* speed: an integer level
+  (`0` = liveliest; higher = calmer, range varies per scene), `"auto"` (default —
+  follow the scene's saved/Govee-recommended speed), or `"off"` (upload the scene
+  baseline untouched). Re-applies the current effect immediately.
+- **`govee-ble-lights.set_scene_speed`** — save (or clear) a per-scene speed
+  preset for the current effect. An integer pins that scene's speed for every strip
+  that's on `"auto"`; `"auto"` clears the preset back to Govee's default. Presets
+  persist to Home Assistant storage (survive restarts and HACS updates).
+
+Resolution precedence: **strip's pinned level → saved scene preset → `auto`
+(Govee's per-scene `defaultIndex`)**. Each light exposes `speed_index`,
+`scene_speed_preset` and `resolved_speed` attributes so the active level is visible.
+
+> Speed "feel" is per-scene: the byte's direction and range depend on the scene's
+> colour type, so the same level looks different across scenes. Inherently flashing
+> scenes (e.g. fireworks) still flicker even at their calmest level.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,54 @@ A powerful and seamless integration to control your Govee lighting devices via G
 
 ---
 
+## Fork additions: H617A dynamic scenes over BLE
+
+This fork adds working **dynamic scene** support for the **H617A** RGBIC strip over
+local BLE, plus a more resilient BLE transport. Changes live in
+`custom_components/govee-ble-lights/light.py` and add the scene catalogue
+`jsons/H617A.json` (payload-identical to the already-bundled `H617C.json`).
+
+### The missing "activate scene" command
+
+On the H617A, uploading a scene's `scenceParam` with the `0xa3` multi-packet
+protocol only *loads* the scene into the strip's memory — it does **not** switch
+the strip out of manual-colour mode, so the scene never plays. The strip starts
+animating only after an explicit **activate** packet:
+
+```
+33 05 04 <sceneCodeLo> <sceneCodeHi>      # sceneCode is 2-byte little-endian
+```
+
+`sceneCode` comes from the model JSON per light-effect. So setting a scene is two
+steps over one BLE session: **(1)** send the `0xa3` `scenceParam` upload, **(2)**
+send the activate packet. This was reverse-engineered live on H617A hardware;
+~25 scenes across all nine categories animate correctly from the standard
+Home Assistant effect dropdown.
+
+### BLE transport hardening
+
+- All packets of a command ride **one** freshly-established connection; the link
+  is held open briefly so a scene upload commits, then closed on an idle timer
+  (so it doesn't hog a Bluetooth-proxy connection slot).
+- A held connection is never reused (an idle strip behind an ESPHome BLE proxy
+  keeps reporting `is_connected == True` while silently dropping
+  write-without-response packets).
+- Per-entity command lock + a module-level connect lock serialise access to the
+  shared adapter; `available` reflects the BT stack; state survives restarts via
+  `RestoreEntity`. Effect names are rendered readably (`Category - Scene`).
+
+### Known limitations
+
+- **Scene speed** is intrinsic to each scene's payload and is not yet adjustable;
+  most scenes therefore play faster than the app default. The separate BLE speed
+  command has not been identified (it is **not** a trailing byte on the activate
+  packet).
+- A small number of scenes whose intrinsic speed is ~0 load correct colours but
+  appear static (e.g. `Festival - Carnival`) — likely the same missing speed
+  command.
+
+---
+
 ## Configuration
 
 ### What is needed

--- a/custom_components/govee-ble-lights/config_flow.py
+++ b/custom_components/govee-ble-lights/config_flow.py
@@ -33,11 +33,20 @@ class GoveeConfigFlow(ConfigFlow, domain=DOMAIN):
             CONF_TYPE_BLE: 'BLE',
         }
 
-        jsons_path = Path(Path(__file__).parent / "jsons")
-        for file in jsons_path.iterdir():
-            self._available_models.append(file.name.replace(".json", ""))
+    async def _async_ensure_models(self) -> None:
+        """Populate the model list from the bundled catalogues, off the event loop.
 
-        self._available_models.sort()
+        Scanning the jsons/ directory is blocking I/O, so it must not run in
+        __init__ (which executes on the event loop). Done lazily here and cached.
+        """
+        if self._available_models:
+            return
+        jsons_path = Path(__file__).parent / "jsons"
+
+        def _scan() -> list[str]:
+            return sorted(f.name.replace(".json", "") for f in jsons_path.iterdir())
+
+        self._available_models = await self.hass.async_add_executor_job(_scan)
 
     async def async_step_bluetooth(
             self, discovery_info: BluetoothServiceInfoBleak
@@ -61,6 +70,7 @@ class GoveeConfigFlow(ConfigFlow, domain=DOMAIN):
                 CONF_MODEL: model
             })
 
+        await self._async_ensure_models()
         self._set_confirm_only()
         placeholders = {
             "name": title,
@@ -101,6 +111,7 @@ class GoveeConfigFlow(ConfigFlow, domain=DOMAIN):
             self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         errors = {}
+        await self._async_ensure_models()
         current_addresses = self._async_current_ids()
         for discovery_info in async_discovered_service_info(self.hass, False):
             address = discovery_info.address

--- a/custom_components/govee-ble-lights/govee_scene_speed.py
+++ b/custom_components/govee-ble-lights/govee_scene_speed.py
@@ -1,0 +1,154 @@
+"""Apply per-scene speed to an H617A scenceParam blob, the way the Govee app does.
+
+Background (reverse-engineered from Govee Home 7.5.20, class
+``com.govee.base2light.ac.diy.speed.SceneSpeedM`` + ``ParamsV2``):
+
+There is no separate BLE "speed" command. Before uploading a dynamic scene, the
+app rewrites speed bytes *inside* the scenceParam blob, choosing values from the
+scene's ``speedInfo.config`` lookup table at a chosen speed index. The bundled
+catalogue blobs ship at a baseline (often the slowest level), so uploading them
+verbatim plays some scenes too fast/slow and leaves a few (e.g. Festival -
+Carnival, whose movement ships at index 0) looking static. This module reproduces
+the app's rewrite so scenes play at their intended speed.
+
+Blob layout (sceneType 2, the RGBIC format ``RgbICEffect.k()`` serialises):
+  byte[0] = effect-segment count, then that many segments back to back.
+  Each segment:
+    [0]   = segLen-1                         (so segLen = blob[S]+1)
+    [1]   = packed area nibbles
+    [2]   = colour-type selector
+    [3:5] = 2 type bytes
+    [5]   = brightness "j"
+    [6]   = brightness block count nB
+    [7 ..]= nB * 6-byte BrightnessEffect blocks; speed field = byte[3] of each
+    then  ColorEffect: [icByte][b=SPEED][c][nC] + nC*3 RGB
+    then  InAreaMoveEffect: [packed][c][d=SPEED]      (3 bytes)
+    then  AreaMoveEffect:   [packed][c][d=SPEED][e]   (4 bytes)
+
+Speed fields written from the per-page table, indexed by the speed level:
+  color[idx]   -> ColorEffect.b
+  moveIn[idx]  -> InAreaMoveEffect.d
+  moveAll[idx] -> AreaMoveEffect.d
+  bright[k].brightValue[idx] -> k-th BrightnessEffect.d
+
+Page N in the config maps to effect-segment index N (0-based), matching
+SceneSpeedM.g(); pages with no matching segment (and vice-versa) are left alone.
+Any structural surprise leaves the blob untouched, so an unexpected format
+degrades to current behaviour rather than corrupting the upload.
+"""
+from __future__ import annotations
+
+import json
+
+
+def _segment_offsets(blob: bytes):
+    """Yield per-segment dicts of absolute byte offsets for the speed fields.
+
+    Raises ValueError if the blob does not match the sceneType-2 layout, so the
+    caller can fall back to the unmodified blob.
+    """
+    if not blob:
+        raise ValueError("empty blob")
+    count = blob[0]
+    off = 1
+    for idx in range(count):
+        s = off
+        if s + 7 > len(blob):
+            raise ValueError("segment header past end")
+        seg_len = blob[s] + 1
+        n_bright = blob[s + 6]
+        bright_d = [s + 7 + 6 * i + 3 for i in range(n_bright)]
+        color_start = s + 7 + 6 * n_bright
+        if color_start + 4 > len(blob):
+            raise ValueError("colour block past end")
+        color_b = color_start + 1
+        n_color = blob[color_start + 3]
+        in_start = color_start + 4 + 3 * n_color
+        movein_d = in_start + 2
+        area_start = in_start + 3
+        moveall_d = area_start + 2
+        seg_end = area_start + 4
+        if seg_end - s != seg_len or seg_end > len(blob):
+            raise ValueError("segment length mismatch")
+        yield {
+            "idx": idx,
+            "bright_d": bright_d,
+            "color_b": color_b,
+            "movein_d": movein_d,
+            "moveall_d": moveall_d,
+        }
+        off = seg_end
+    if off != len(blob):
+        raise ValueError("trailing bytes after segments")
+
+
+def _at(arr, index):
+    """Value at `index`, clamped into the array; None if no array/values."""
+    if not arr:
+        return None
+    if index < 0:
+        index = 0
+    elif index >= len(arr):
+        index = len(arr) - 1
+    return arr[index]
+
+
+def apply_scene_speed(param: bytes, config: str | None,
+                      override_index: int | None = None) -> bytes:
+    """Return `param` with speed bytes set per `config`, or `param` unchanged.
+
+    config: the scene's ``speedInfo['config']`` string (JSON list of page dicts).
+    override_index: speed level to apply to every page; if None, each page's own
+        ``defaultIndex`` is used (the app's default slider position).
+    """
+    try:
+        pages = json.loads(config) if config else None
+    except (ValueError, TypeError):
+        return param
+    if not pages:
+        return param
+
+    by_page = {}
+    for page in pages:
+        try:
+            by_page[int(page.get("page"))] = page
+        except (TypeError, ValueError):
+            continue
+    if not by_page:
+        return param
+
+    try:
+        segments = list(_segment_offsets(param))
+    except ValueError:
+        return param  # unknown layout -> upload as-is
+
+    blob = bytearray(param)
+    for seg in segments:
+        page = by_page.get(seg["idx"])
+        if page is None:
+            continue
+        if override_index is not None:
+            index = override_index
+        else:
+            try:
+                index = int(page.get("defaultIndex", 0))
+            except (TypeError, ValueError):
+                index = 0
+
+        color = _at(page.get("color"), index)
+        if color is not None:
+            blob[seg["color_b"]] = color & 0xFF
+        move_in = _at(page.get("moveIn"), index)
+        if move_in is not None:
+            blob[seg["movein_d"]] = move_in & 0xFF
+        move_all = _at(page.get("moveAll"), index)
+        if move_all is not None:
+            blob[seg["moveall_d"]] = move_all & 0xFF
+
+        bright = page.get("bright") or []
+        for k, offset in enumerate(seg["bright_d"]):
+            if k < len(bright):
+                value = _at(bright[k].get("brightValue"), index)
+                if value is not None:
+                    blob[offset] = value & 0xFF
+    return bytes(blob)

--- a/custom_components/govee-ble-lights/jsons/H617A.json
+++ b/custom_components/govee-ble-lights/jsons/H617A.json
@@ -1,0 +1,11068 @@
+{
+  "message": "success",
+  "status": 200,
+  "data": {
+    "categories": [
+      {
+        "categoryId": 5,
+        "categoryName": "Natural",
+        "scenes": [
+          {
+            "sceneId": 128,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/08070a5ba20c0f3e11114563b931d961-new_light_btn_scenes_morning%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/e485c606078415fd1d044d380786f244-new_light_btn_scenes_morning_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/a76af9e9c06898981282d5fb74930645-new_light_btn_scenes_morning_dark%403x.png"
+            ],
+            "sceneName": "Sunrise",
+            "analyticName": "Sunrise",
+            "sceneType": 0,
+            "sceneCode": 0,
+            "scenceCategoryId": 5,
+            "popUpPrompt": 1,
+            "scenesHint": "Sunrise: The light will mimic the sunrise color, The brightness will increase continuously, reaching its brightest level after 15 minutes.",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 110,
+                "scenceName": "",
+                "scenceParam": "",
+                "sceneCode": 0,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 0,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 129,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/scence-img/b2436666e39e49d75608997e1f5ace65-new_light_btn_scenes_sunset%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/scence-img/fc453d944fd5e97edfaa6a426f35438a-new_light_btn_scenes_sunset_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/scence-img/73337f4bea682300e3d46243ae3d3316-new_light_btn_scenes_sunset_dark%403x.png"
+            ],
+            "sceneName": "Sunset",
+            "analyticName": "Sunset",
+            "sceneType": 0,
+            "sceneCode": 1,
+            "scenceCategoryId": 5,
+            "popUpPrompt": 1,
+            "scenesHint": "Sunset: The light will mimic the sunset color. The brightness will decrease to its lowest level after 10 minutes. ",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 111,
+                "scenceName": "",
+                "scenceParam": "",
+                "sceneCode": 1,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 0,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 130,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/89660c742b8fe41f19df9c0d703e4d8b-new_light_btn_scenes_green_forest%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/942511433fb7ed20cde18ee557d1eb2a-new_light_btn_scenes_green_forest_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/9a2b148cc02374c1feeede17c0662901-new_light_btn_scenes_green_forest_dark%403x.png"
+            ],
+            "sceneName": "Forest",
+            "analyticName": "Forest",
+            "sceneType": 2,
+            "sceneCode": 212,
+            "scenceCategoryId": 5,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 112,
+                "scenceName": "",
+                "scenceParam": "AyYAAQAKAgH/GQG0CgoCyBQF//8AAP//////AP//lP8AFAGWAAAAACMAAg8FAgH/FAH7AAAB+goEBP8AtP8AR///4/8AAAAAAAAAABoAAAABAgH/BQHIFBQC7hQBAP8AAAAAAAAAAA==",
+                "sceneCode": 212,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11238,
+                    "scenceParam": "AyYAAQAKAgH/GQG0CgoCyBQF//8AAP//////AP//lP8AFAGWAAAAACMAAg8FAgH/FAH7AAAB+goEBP8AtP8AR///4/8AAAAAAAAAABoAAAABAgH/BQHIFBQC7hQBAP8AAAAAAAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":2,\"color\":[239,244,250],\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[204,209,216]}],\"page\":1},{\"page\":2,\"defaultIndex\":2,\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[193,200,200]}],\"color\":[229,238,238]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31238,
+                    "scenceParam": "AyYAAQAKAgH/GQG0CgoCyBQF//8AAP//////AP//lP8AFAGWAAAAACMAAg8FAgH/FAH7AAAB+goEBP8AtP8AR///4/8AAAAAAAAAABoAAAABAgH/BQHIFBQC7hQBAP8AAAAAAAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\": 2, \"color\": [244, 249, 255], \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [204, 219, 216]}], \"page\": 1}, {\"page\": 2, \"defaultIndex\": 2, \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [193, 210, 200]}], \"color\": [234, 243, 243]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 131,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/fcd5d6cfea25f4ed5a2b51ea08ab8cdd-new_light_btn_scenes_green_shadow%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/b6a44c5b4265e0293a704766b47e5024-new_light_btn_scenes_green_shadow_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/28e90272452f261d8c4ad8f9fd09c707-new_light_btn_scenes_green_shadow_dark%403x.png"
+            ],
+            "sceneName": "Rustling leaves",
+            "analyticName": "Rustling leaves",
+            "sceneType": 2,
+            "sceneCode": 218,
+            "scenceCategoryId": 5,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 113,
+                "scenceName": "",
+                "scenceParam": "Ah0AAAABAAH//wEAAAAA3DICAP8AAf+WAAAAAAAAABoAAigBAgH/KAHMIBQAADIB//8AAAAAAAAAAA==",
+                "sceneCode": 218,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 132,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/44ff0ccc9173ffb9a7ab30415bffc249-new_light_btn_scenes_universe%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/5212e281b77e4ebf4ed17f7243c07655-new_light_btn_scenes_universe_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/8c2c7aa0b04d74a4c7dc5dc245ba0d2a-new_light_btn_scenes_universe_dark%403x.png"
+            ],
+            "sceneName": "Universe",
+            "analyticName": "Universe",
+            "sceneType": 2,
+            "sceneCode": 200,
+            "scenceCategoryId": 5,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 114,
+                "scenceName": "A",
+                "scenceParam": "AyNQAQAPAgH/CgIAAAACAAAEAAD/AKr/AP//////AAD6EAH+ACNVAQAPAgH/CgAAAAACAAAE////AP//AKr/AAD/AAD6EgH+ABoAAAABAAH6AAHIMhQA/zIBAAD/EQCAAAAAAA==",
+                "sceneCode": 200,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11239,
+                    "scenceParam": "AyNQAQAPAgH/CgIAAAACAAAEAAD/AKr/AP//////AAD6EAH+ACNVAQAPAgH/CgAAAAACAAAE////AP//AKr/AAD/AAD6EgH+ABoAAAABAAH6AAHIMhQA/zIBAAD/EQCAAAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\":0,\"moveAll\":[247,252,255],\"defaultIndex\":1},{\"defaultIndex\":1,\"page\":1,\"moveAll\":[247,252,255]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31239,
+                    "scenceParam": "AyNQAQAPAgH/CgIAAAACAAAEAAD/AKr/AP//////AAD6EAH+ACNVAQAPAgH/CgAAAAACAAAE////AP//AKr/AAD/AAD6EgH+ABoAAAABAAH6AAHIMhQA/zIBAAD/EQCAAAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\": 0, \"moveAll\": [247, 252, 255], \"defaultIndex\": 2}, {\"defaultIndex\": 2, \"page\": 1, \"moveAll\": [247, 252, 255]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 2882,
+                "scenceName": "B",
+                "scenceParam": "BSkAAzIAAAEzMwIAAQGDNAEGAAD/iwD/AAD/AP//AAD/iwD/AADXAAAdACYAAg8BAAL/AALMAQH/AADIAQEDNAEDAP//AAD//wAABAD/AACAACklAAABAAP/AALJAf//AADJBwEAAAAAATIDAAECAAAA////FgD0EgD8ACkjAAABAAP/AALKAf//AADLBwEAAAAAAY8DAAECAAAA////FADzEAD7ACkkAAABAAP/AALKAf//AADKBwEAAAAAASMDAAECAAAA////FAD2EAD+AA==",
+                "sceneCode": 2499,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11240,
+                    "scenceParam": "BSkAAzIAAAEzMwIAAQGDNAEGAAD/iwD/AAD/AP//AAD/iwD/AADXAAAdACYAAg8BAAL/AALMAQH/AADIAQEDNAEDAP//AAD//wAABAD/AACAACklAAABAAP/AALJAf//AADJBwEAAAAAATIDAAECAAAA////FgD0EgD8ACkjAAABAAP/AALKAf//AADLBwEAAAAAAY8DAAECAAAA////FADzEAD7ACkkAAABAAP/AALKAf//AADKBwEAAAAAASMDAAECAAAA////FAD2EAD+AA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":0,\"bright\":[{\"brightValue\":[204,206,209],\"brightPage\":\"0\"},{\"brightPage\":\"1\",\"brightValue\":[200,204,209]}],\"page\":1}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31240,
+                    "scenceParam": "BSkAAzIAAAEzMwIAAQGDNAEGAAD/iwD/AAD/AP//AAD/iwD/AADXAAAdACYAAg8BAAL/AALMAQH/AADIAQEDNAEDAP//AAD//wAABAD/AACAACklAAABAAP/AALJAf//AADJBwEAAAAAATIDAAECAAAA////FgD0EgD8ACkjAAABAAP/AALKAf//AADLBwEAAAAAAY8DAAECAAAA////FADzEAD7ACkkAAABAAP/AALKAf//AADKBwEAAAAAASMDAAECAAAA////FAD2EAD+AA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\": 1, \"bright\": [{\"brightValue\": [204, 216, 209], \"brightPage\": \"0\"}, {\"brightPage\": \"1\", \"brightValue\": [200, 214, 209]}], \"page\": 1}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 133,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/bdd9f615067c8ac3211193b16e35fcdb-new_light_btn_scenes_star_meteor%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/208bc1caa42e3f0535826e4589b39f38-new_light_btn_scenes_star_meteor_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/3dc3f90bf98458d289bd650d044f6692-new_light_btn_scenes_star_meteor_dark%403x.png"
+            ],
+            "sceneName": "Meteor",
+            "analyticName": "Meteor",
+            "sceneType": 2,
+            "sceneCode": 205,
+            "scenceCategoryId": 5,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 115,
+                "scenceName": "",
+                "scenceParam": "ASAgAQAKAgH/CgIAAAACAAADAKr/AP//////AAD6EAH+AA==",
+                "sceneCode": 205,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11241,
+                    "scenceParam": "ASAgAQAKAgH/CgIAAAACAAADAKr/AP//////AAD6EAH+AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":2,\"page\":0,\"moveAll\":[249,252,254]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31241,
+                    "scenceParam": "ASAgAQAKAgH/CgIAAAACAAADAKr/AP//////AAD6EAH+AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":2,\"page\":0,\"moveAll\":[249,252,254]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 134,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/8e05d68521a66b7e6121fe08706ff020-new_light_btn_scenes_meteor%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/22bb5ecc205ee3e6351ae4a52ca6614d-new_light_btn_scenes_meteor_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/9d3e65e90c3e01965736a5d54f5a6723-new_light_btn_scenes_meteor_dark%403x.png"
+            ],
+            "sceneName": "Meteor shower",
+            "analyticName": "Meteor shower",
+            "sceneType": 2,
+            "sceneCode": 228,
+            "scenceCategoryId": 5,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 116,
+                "scenceName": "",
+                "scenceParam": "AyAgAQAKAgH/CgIAAAACAAADANv/AP//////AAD6EAH9ACAAAQAKAgH/CgIAAAACAAADANv/AP//////AAD6EAH8ACBVAQAKAgH/CgIAAAACAAADAAD/AP//////AAD6EAH9AA==",
+                "sceneCode": 228,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11242,
+                    "scenceParam": "AyAgAQAKAgH/CgIAAAACAAADANv/AP//////AAD6EAH9ACAAAQAKAgH/CgIAAAACAAADANv/AP//////AAD6EAH8ACBVAQAKAgH/CgIAAAACAAADAAD/AP//////AAD6EAH9AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\":0,\"defaultIndex\":1,\"moveAll\":[247,252,255]},{\"moveAll\":[247,252,252],\"page\":1,\"defaultIndex\":1},{\"moveAll\":[247,253,252],\"page\":2,\"defaultIndex\":1}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31242,
+                    "scenceParam": "AyAgAQAKAgH/CgIAAAACAAADANv/AP//////AAD6EAH9ACAAAQAKAgH/CgIAAAACAAADANv/AP//////AAD6EAH8ACBVAQAKAgH/CgIAAAACAAADAAD/AP//////AAD6EAH9AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\": 0, \"defaultIndex\": 2, \"moveAll\": [247, 252, 255]}, {\"moveAll\": [247, 252, 252], \"page\": 1, \"defaultIndex\": 2}, {\"moveAll\": [247, 253, 252], \"page\": 2, \"defaultIndex\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 135,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/57547e4df41a0435e0564d4688a4a6fd-new_light_btn_scenes_northern_light%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/fb10d7e26a71b57f1e03736e123c2494-new_light_btn_scenes_northern_light_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/612b6d13221d3814f225b7a8435dc1b2-new_light_btn_scenes_northern_light_dark%403x.png"
+            ],
+            "sceneName": "Aurora",
+            "analyticName": "Aurora",
+            "sceneType": 2,
+            "sceneCode": 215,
+            "scenceCategoryId": 5,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 117,
+                "scenceName": "A",
+                "scenceParam": "AiAAAAABAgH/MgEAAAAA+jIDAP8AAP//qv8AAwCAAAAAACMAAAADAgH/GQD6AAAC+gAEf/8A//8AoP//AP//FAH6AAD/AA==",
+                "sceneCode": 215,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 1771,
+                "scenceName": "B",
+                "scenceParam": "BCNAAAABAgH/GQPCCgMC5jIED/8ICwf/B/j//wbpAAL4AQCAACNCAAABAAH/GAO7CgOC5zIE/9Nyy4X/DUv/Uv+ZEgHNAAPkACNEAAABAAH/GAO7CgMC5TIECwf/D/8I/wbpB/j/EAHMAQCAACZGAAABAAH/GAO7CgMC5TIFB/j/Cwf//wbpD/8I3P8REgHdAQCAAA==",
+                "sceneCode": 2289,
+                "specialEffect": [],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 136,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/d6e18e52c0f8b24b727ff59475e91286-new_light_btn_scenes_thunder%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/78b0a7ac2affbd3d470ab10be25060b1-new_light_btn_scenes_thunder_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/35d6aaac3c8835b4f0bae5b5f51bd964-new_light_btn_scenes_thunder_dark%403x.png"
+            ],
+            "sceneName": "Lightning",
+            "analyticName": "Lightning",
+            "sceneType": 2,
+            "sceneCode": 214,
+            "scenceCategoryId": 5,
+            "popUpPrompt": 2,
+            "scenesHint": "Those with epilepsy may experience discomfort when using this Scene mode. Exercise caution during use.",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 118,
+                "scenceName": "A",
+                "scenceParam": "Ah0AAg8FAAH/AAD/AgIA/zIC////AAAAEQCAAAAAAB0AAAABAAH/AAH/AgIA/zICAAAA////EQCAAAAAAA==",
+                "sceneCode": 214,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11243,
+                    "scenceParam": "Ah0AAg8FAAH/AAD/AgIA/zIC////AAAAEQCAAAAAAB0AAAABAAH/AAH/AgIA/zICAAAA////EQCAAAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":1,\"color\":[242,247,252],\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[214,229,244]}],\"page\":0},{\"bright\":[{\"brightValue\":[211,211,234],\"brightPage\":\"0\"}],\"color\":[244,249,252],\"defaultIndex\":1,\"page\":1}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31243,
+                    "scenceParam": "Ah0AAg8FAAH/AAD/AgIA/zIC////AAAAEQCAAAAAAB0AAAABAAH/AAH/AgIA/zICAAAA////EQCAAAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\": 2, \"color\": [247, 252, 255], \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [214, 239, 244]}], \"page\": 0}, {\"bright\": [{\"brightValue\": [211, 221, 234], \"brightPage\": \"0\"}], \"color\": [249, 254, 255], \"defaultIndex\": 2, \"page\": 1}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 402,
+                "scenceName": "B",
+                "scenceParam": "ASmBAgEBAgH/AAH/AQEC/yMG////AAAA////AAAA////AAAAFQXMEQXNAA==",
+                "sceneCode": 2133,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 403,
+                "scenceName": "C",
+                "scenceParam": "BRokAAABAgH/AAP/FBQAABQBAAD/AACAAACAARoAAAABAgH/AAH/FBQAABQBAAD/AACAAACAARogAQAKAgH/AAKAFBQAgBQB////AACAEAH7AhooAQAKAgH/AACAFBQAgBQB////AACAEgH7Ah0kAQAKAgH/AAP/BAEA/woCAAD/////AACAAACAAQ==",
+                "sceneCode": 2100,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11244,
+                    "scenceParam": "BRokAAABAgH/AAP/FBQAABQBAAD/AACAAACAARoAAAABAgH/AAH/FBQAABQBAAD/AACAAACAARogAQAKAgH/AAKAFBQAgBQB////AACAEAH7AhooAQAKAgH/AACAFBQAgBQB////AACAEgH7Ah0kAQAKAgH/AAP/BAEA/woCAAD/////AACAAACAAQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\":2,\"moveAll\":[244,252,255],\"defaultIndex\":1},{\"defaultIndex\":1,\"moveAll\":[244,252,255],\"page\":3},{\"color\":[252,255,255],\"defaultIndex\":1,\"page\":4,\"bright\":[{\"brightValue\":[244,255,255],\"brightPage\":\"0\"}]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31244,
+                    "scenceParam": "BRokAAABAgH/AAP/FBQAABQBAAD/AACAAACAARoAAAABAgH/AAH/FBQAABQBAAD/AACAAACAARogAQAKAgH/AAKAFBQAgBQB////AACAEAH7AhooAQAKAgH/AACAFBQAgBQB////AACAEgH7Ah0kAQAKAgH/AAP/BAEA/woCAAD/////AACAAACAAQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\": 2, \"moveAll\": [244, 252, 255], \"defaultIndex\": 2}, {\"defaultIndex\": 2, \"moveAll\": [244, 252, 255], \"page\": 3}, {\"color\": [255, 255, 255], \"defaultIndex\": 2, \"page\": 4, \"bright\": [{\"brightValue\": [244, 255, 255], \"brightPage\": \"0\"}]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 137,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/f0ef6e6762cf2b4baeb6bf360075a599-new_light_btn_scenes_star_sky%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/7ee06dc3d64857db675a427d58d2bfc8-new_light_btn_scenes_star_sky_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/44db10066e879811b74aa2be25322cc3-new_light_btn_scenes_star_sky_dark%403x.png"
+            ],
+            "sceneName": "Starry Sky",
+            "analyticName": "Starry Sky",
+            "sceneType": 2,
+            "sceneCode": 217,
+            "scenceCategoryId": 5,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 119,
+                "scenceName": "",
+                "scenceParam": "AiAAAAACAAH/GQF4MjICyDIDAAD/AH7/AAD/AAAAAAAAACMAAg8DAAH/FAH6FBQC/TIEAAD/////AOz/AAD/AAAAAAAAAA==",
+                "sceneCode": 217,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11246,
+                    "scenceParam": "AiAAAAACAAH/GQF4MjICyDIDAAD/AH7/AAD/AAAAAAAAACMAAg8DAAH/FAH6FBQC/TIEAAD/////AOz/AAD/AAAAAAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\":1,\"color\":[201,229,253],\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[201,211,250]}],\"defaultIndex\":2}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31246,
+                    "scenceParam": "AiAAAAACAAH/GQF4MjICyDIDAAD/AH7/AAD/AAAAAAAAACMAAg8DAAH/FAH6FBQC/TIEAAD/////AOz/AAD/AAAAAAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\": 1, \"color\": [206, 234, 255], \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [201, 221, 250]}], \"defaultIndex\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 138,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/a245276d6cdb756255e7288fd65a7931-new_light_btn_scenes_star_flash%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/fd4364eed1f9c9e1d445923a36759132-new_light_btn_scenes_star_flash_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/ddfe4082c144fb03250ae121c0f2d21e-new_light_btn_scenes_star_flash_dark%403x.png"
+            ],
+            "sceneName": "Star",
+            "analyticName": "Star",
+            "sceneType": 2,
+            "sceneCode": 213,
+            "scenceCategoryId": 5,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 120,
+                "scenceName": "",
+                "scenceParam": "Ah0AAg8FAgH/AACWMjIA3DIC////b///AAAAAAAAAB0AAgoDAgH/AADcFBQA3DIC////b///AAAAAAAAAA==",
+                "sceneCode": 213,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11245,
+                    "scenceParam": "Ah0AAg8FAgH/AACWMjIA3DIC////b///AAAAAAAAAB0AAgoDAgH/AADcFBQA3DIC////b///AAAAAAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\":1,\"color\":[201,229,253],\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[201,211,250]}],\"defaultIndex\":2}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31245,
+                    "scenceParam": "Ah0AAg8FAgH/AACWMjIA3DIC////b///AAAAAAAAAB0AAgoDAgH/AADcFBQA3DIC////b///AAAAAAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\": 1, \"color\": [206, 234, 255], \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [201, 221, 250]}], \"defaultIndex\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 139,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/b1cf244bed32474e40a95cc579670075-new_light_btn_scenes_snow%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/3ed205dbc06a7b69d8d517b4fcd6d1de-new_light_btn_scenes_snow_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/e70fb8097d5a93108fe89678e3252c0d-new_light_btn_scenes_snow_dark%403x.png"
+            ],
+            "sceneName": "Snow flake",
+            "analyticName": "Snow flake",
+            "sceneType": 0,
+            "sceneCode": 15,
+            "scenceCategoryId": 5,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 121,
+                "scenceName": "A",
+                "scenceParam": "",
+                "sceneCode": 15,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 0,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 425,
+                "scenceName": "B",
+                "scenceParam": "BSkAAAAyAAH/AAB/FBQAthQGAAAAAAAA//n3aZH/AAAAAAAAFAD3AAB/ASlQAgUBAAH/AAB/FBQA/xQG+//7AAAA////AAAAg5j/AAAAFAD8AAB/BSZSAgUBAAH/AAF/FBQA/xQF+//7AAAA////AAAA/4D9FQT8EQbZASZVAgEBAAH/AAB/FBQA/xQF+//7AAAA////AAAAorH/FQT8AAB/ASkAAgUBAAH/AAB/FBQA/xQG+//7AAAA////AAAAvX//f4T/FQD8AAB/AQ==",
+                "sceneCode": 2154,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11247,
+                    "scenceParam": "BSkAAAAyAAH/AAB/FBQAthQGAAAAAAAA//n3aZH/AAAAAAAAFAD3AAB/ASlQAgUBAAH/AAB/FBQA/xQG+//7AAAA////AAAAg5j/AAAAFAD8AAB/BSZSAgUBAAH/AAF/FBQA/xQF+//7AAAA////AAAA/4D9FQT8EQbZASZVAgEBAAH/AAB/FBQA/xQF+//7AAAA////AAAAorH/FQT8AAB/ASkAAgUBAAH/AAB/FBQA/xQG+//7AAAA////AAAAvX//f4T/FQD8AAB/AQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":1,\"page\":0,\"color\":[173,182,183],\"moveIn\":[239,247,252]},{\"defaultIndex\":1,\"page\":1,\"color\":[252,255,255],\"moveIn\":[234,242,252]},{\"defaultIndex\":1,\"color\":[252,255,255],\"moveIn\":[229,239,252],\"page\":2},{\"moveIn\":[229,237,252],\"page\":3,\"defaultIndex\":1,\"color\":[252,255,255]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31247,
+                    "scenceParam": "BSkAAAAyAAH/AAB/FBQAthQGAAAAAAAA//n3aZH/AAAAAAAAFAD3AAB/ASlQAgUBAAH/AAB/FBQA/xQG+//7AAAA////AAAAg5j/AAAAFAD8AAB/BSZSAgUBAAH/AAF/FBQA/xQF+//7AAAA////AAAA/4D9FQT8EQbZASZVAgEBAAH/AAB/FBQA/xQF+//7AAAA////AAAAorH/FQT8AAB/ASkAAgUBAAH/AAB/FBQA/xQG+//7AAAA////AAAAvX//f4T/FQD8AAB/AQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\": 2, \"page\": 0, \"color\": [178, 187, 188], \"moveIn\": [239, 247, 252]}, {\"defaultIndex\": 2, \"page\": 1, \"color\": [255, 255, 255], \"moveIn\": [234, 252, 252]}, {\"defaultIndex\": 2, \"color\": [255, 255, 255], \"moveIn\": [229, 249, 252], \"page\": 2}, {\"moveIn\": [229, 247, 252], \"page\": 3, \"defaultIndex\": 2, \"color\": [255, 255, 255]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 140,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/1b3b1ad0b4b91d79cfc8e4e3e8a254fb-new_light_btn_scenes_spring%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/2eca57558d8bcd1a6cba8a4fb7d923b5-new_light_btn_scenes_spring_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/c34335d5cebc5015430d598533d00407-new_light_btn_scenes_spring_dark%403x.png"
+            ],
+            "sceneName": "Spring",
+            "analyticName": "Spring",
+            "sceneType": 2,
+            "sceneCode": 210,
+            "scenceCategoryId": 5,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 122,
+                "scenceName": "",
+                "scenceParam": "AykAAgoFAgH/GQAAAAAC+jIG/zgA/38AAP8AAAAAAP//iwD/AACAAAAAACMAAh4KAAH//wAAAAAB+gAE8QAd/3UA/8AA/0sAAAD/AAH6AB0AAAABAAEyAAHIMjICyDICAP8A//8AAAAAAAAAAA==",
+                "sceneCode": 210,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 141,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/99c6631bece4f5204ad8a95f38ddcf8b-new_light_btn_scenes_summer%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/597856282239cb176467801e1802c0ff-new_light_btn_scenes_summer_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/87e8e88f42596685530986587a1a6e8c-new_light_btn_scenes_summer_dark%403x.png"
+            ],
+            "sceneName": "Summer",
+            "analyticName": "Summer",
+            "sceneType": 2,
+            "sceneCode": 223,
+            "scenceCategoryId": 5,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 123,
+                "scenceName": "A",
+                "scenceParam": "AhoAAAABAgH//wAAAAAA/zIBM///AwCAAAAAACYAAh4KAAH//wAAAAAA+gAFAAD/AP///8AA//8AAAX/AAAAAAD/AA==",
+                "sceneCode": 223,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 1760,
+                "scenceName": "B",
+                "scenceParam": "BBoQAAABAAH//wCAFBQCABQBAP8AAACAAACAABqBAhkUAAH//wCAFBQCABQB/1FJAACAAACAARqBAhkUAAH//wCAFBQCABQB/wAAAACAAACAAhoZAAABAAH//wCAFBQCABQBAP8AAACAAACAAA==",
+                "sceneCode": 2280,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 142,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/e7d4ad0d5e347a6ad55f0bd2e66d0570-new_light_btn_scenes_fall%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/bbdd0096b29a8b5d5439d912e4962450-new_light_btn_scenes_fall_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/fff64afab08960196984e3e3dc08260a-new_light_btn_scenes_fall_dark%403x.png"
+            ],
+            "sceneName": "Fall",
+            "analyticName": "Fall",
+            "sceneType": 2,
+            "sceneCode": 202,
+            "scenceCategoryId": 5,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 124,
+                "scenceName": "",
+                "scenceParam": "AhoAAAABAgH//wAAAAAA/zIB/zgAAwCAAAAAACkAAh4KAAH//wAAAAAA+gAG8QAd/3UA/8AA/0sA/wAAAAAAEADcAAD/AA==",
+                "sceneCode": 202,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11248,
+                    "scenceParam": "AhoAAAABAgH//wAAAAAA/zIB/zgAAwCAAAAAACkAAh4KAAH//wAAAAAA+gAG8QAd/3UA/8AA/0sA/wAAAAAAEADcAAD/AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":0,\"page\":1,\"color\":[250,252,252],\"moveIn\":[220,244,252]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31248,
+                    "scenceParam": "AhoAAAABAgH//wAAAAAA/zIB/zgAAwCAAAAAACkAAh4KAAH//wAAAAAA+gAG8QAd/3UA/8AA/0sA/wAAAAAAEADcAAD/AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\": 1, \"page\": 1, \"color\": [255, 255, 255], \"moveIn\": [220, 254, 252]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 143,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/f65bb3c1dff68b8bb7655350329aa65e-new_light_btn_scenes_winter%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/26cb78042ef30bd64a2ef74de1a9be07-new_light_btn_scenes_winter_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/775ede6eff53b0d4ebe280d411aafa36-new_light_btn_scenes_winter_dark%403x.png"
+            ],
+            "sceneName": "Winter",
+            "analyticName": "Winter",
+            "sceneType": 2,
+            "sceneCode": 201,
+            "scenceCategoryId": 5,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 125,
+                "scenceName": "",
+                "scenceParam": "AxoAAAABAgH/CgHIFAoA/TIB////AwCAAAAAACMAAh4KAAH/BQCgFBQB/QAE////t///pv//d///FAHIEQH9/yMAAh4KAAH/BQCgFBQB/QoE////t///pv//d///EQHIEgH8AA==",
+                "sceneCode": 201,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 144,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/c1068ace12a82ee32333f5c35bbc154e-new_light_btn_scenes_four_color%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/9215bf8e3df86bd03eb32b93fd3f5b3b-new_light_btn_scenes_four_color_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/6b7e891d014ba5742fbbc02368e077e9-new_light_btn_scenes_four_color_dark%403x.png"
+            ],
+            "sceneName": "Rainbow",
+            "analyticName": "Rainbow",
+            "sceneType": 0,
+            "sceneCode": 22,
+            "scenceCategoryId": 5,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 126,
+                "scenceName": "A",
+                "scenceParam": "",
+                "sceneCode": 22,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 0,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 11221,
+                "scenceName": "B",
+                "scenceParam": "ASkAAAAHAgH/gQD5FBQD+RQG/wAA/38A//8AAP8AAP//AAD/EAD8AACAAA==",
+                "sceneCode": 10187,
+                "specialEffect": [],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 145,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/6a4f1c125721c2b07e10a551223e603d-new_light_btn_scenes_fire%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/a2ea743032f0947a6ec982d95910b76f-new_light_btn_scenes_fire_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/5b5cd217379f7f729a5cc49c9d215d84-new_light_btn_scenes_fire_dark%403x.png"
+            ],
+            "sceneName": "Fire",
+            "analyticName": "Fire",
+            "sceneType": 2,
+            "sceneCode": 216,
+            "scenceCategoryId": 5,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 127,
+                "scenceName": "A",
+                "scenceParam": "AiAAAAABAgL//wAAAAD/GQAAAAAA/zIB/zgAAwCAAAAAACMAAh4KAAH//wAAAAAA/wAE8QAd/3UA/8AA/0sAAAD/AAD/AA==",
+                "sceneCode": 216,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 364,
+                "scenceName": "B",
+                "scenceParam": "BR0AAAAWAAFwMgO7FBQC1RQC/1kH////AwD/EwD/ASknAAAFAgH/mQL/Xx4CAP8GAAAA/////20H/00H/w4H/wgJEgD8EACAAikhAAAGAgH/mQL/Xx4CAP8GAAAA/////20H/00H/w4H/wgJEAD+EAD9AilDAhQUAAH//wCAFBQB6hQG/xUH/wgJ/wgJ/ykH/wcTAAAAEwD8AACAAykkAAABAAH/AACAFBQB6RQG/xUH/zkH/44H/14H/wcT/w8HFwD5AAD/BA==",
+                "sceneCode": 2098,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11249,
+                    "scenceParam": "BR0AAAAWAAFwMgO7FBQC1RQC/1kH////AwD/EwD/ASknAAAFAgH/mQL/Xx4CAP8GAAAA/////20H/00H/w4H/wgJEgD8EACAAikhAAAGAgH/mQL/Xx4CAP8GAAAA/////20H/00H/w4H/wgJEAD+EAD9AilDAhQUAAH//wCAFBQB6hQG/xUH/wgJ/wgJ/ykH/wcTAAAAEwD8AACAAykkAAABAAH/AACAFBQB6RQG/xUH/zkH/44H/14H/wcT/w8HFwD5AAD/BA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"color\":[213,213,213,224],\"page\":0,\"defaultIndex\":2,\"moveAll\":[226,234,247,252],\"bright\":[{\"brightValue\":[187,187,187,198],\"brightPage\":\"0\"}]},{\"defaultIndex\":2,\"page\":1,\"moveIn\":[229,239,247,249]},{\"page\":2,\"moveIn\":[226,237,244,249],\"defaultIndex\":2,\"moveAll\":[226,237,247,249]},{\"defaultIndex\":2,\"page\":3,\"color\":[224,229,234,244],\"moveIn\":[226,237,247,252]},{\"moveIn\":[226,237,244,252],\"page\":4,\"defaultIndex\":2,\"color\":[219,226,233,244]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31249,
+                    "scenceParam": "BR0AAAAWAAFwMgO7FBQC1RQC/1kH////AwD/EwD/ASknAAAFAgH/mQL/Xx4CAP8GAAAA/////20H/00H/w4H/wgJEgD8EACAAikhAAAGAgH/mQL/Xx4CAP8GAAAA/////20H/00H/w4H/wgJEAD+EAD9AilDAhQUAAH//wCAFBQB6hQG/xUH/wgJ/wgJ/ykH/wcTAAAAEwD8AACAAykkAAABAAH/AACAFBQB6RQG/xUH/zkH/44H/14H/wcT/w8HFwD5AAD/BA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"color\": [213, 213, 213, 224], \"page\": 0, \"defaultIndex\": 3, \"moveAll\": [226, 234, 247, 252], \"bright\": [{\"brightValue\": [187, 187, 192, 198], \"brightPage\": \"0\"}]}, {\"defaultIndex\": 3, \"page\": 1, \"moveIn\": [229, 239, 247, 249]}, {\"page\": 2, \"moveIn\": [226, 237, 244, 249], \"defaultIndex\": 3, \"moveAll\": [226, 237, 247, 249]}, {\"defaultIndex\": 3, \"page\": 3, \"color\": [224, 229, 234, 244], \"moveIn\": [226, 237, 247, 252]}, {\"moveIn\": [226, 237, 244, 252], \"page\": 4, \"defaultIndex\": 3, \"color\": [219, 226, 233, 244]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 1775,
+                "scenceName": "C",
+                "scenceParam": "BCAAAAABAgH/cQG9FBQAORQD/z4A/ygA/1sAECCAAACAACBQAAABAAH//wCAFBQDgBQD/2UA/1EA/30AEAiAEAD8ASBVAAABAAH//wCAFBQDgBQD/1Ew/0cA/1YAEBeAEAD7AiMzAAABAAH/UQGsFBQAgBQE/2IA/1cO/0QA/2YAEQ2AEAD4Aw==",
+                "sceneCode": 2293,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11250,
+                    "scenceParam": "BCAAAAABAgH/cQG9FBQAORQD/z4A/ygA/1sAECCAAACAACBQAAABAAH//wCAFBQDgBQD/2UA/1EA/30AEAiAEAD8ASBVAAABAAH//wCAFBQDgBQD/1Ew/0cA/1YAEBeAEAD7AiMzAAABAAH/UQGsFBQAgBQE/2IA/1cO/0QA/2YAEQ2AEAD4Aw==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\":1,\"moveAll\":[244,252,255],\"defaultIndex\":1,\"moveIn\":[128,128,234]},{\"defaultIndex\":1,\"page\":2,\"moveAll\":[239,251,252],\"moveIn\":[128,128,242]},{\"moveAll\":[239,248,255],\"page\":3,\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[172,172,204]}],\"defaultIndex\":1}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31250,
+                    "scenceParam": "BCAAAAABAgH/cQG9FBQAORQD/z4A/ygA/1sAECCAAACAACBQAAABAAH//wCAFBQDgBQD/2UA/1EA/30AEAiAEAD8ASBVAAABAAH//wCAFBQDgBQD/1Ew/0cA/1YAEBeAEAD7AiMzAAABAAH/UQGsFBQAgBQE/2IA/1cO/0QA/2YAEQ2AEAD4Aw==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\": 1, \"moveAll\": [244, 252, 255], \"defaultIndex\": 2, \"moveIn\": [128, 138, 234]}, {\"defaultIndex\": 2, \"page\": 2, \"moveAll\": [239, 251, 252], \"moveIn\": [128, 138, 242]}, {\"moveAll\": [239, 248, 255], \"page\": 3, \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [172, 182, 204]}], \"defaultIndex\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 146,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/7bb33cd2ab914e917a947d9e7dddccc5-new_light_btn_scenes_ripple%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/cf9dbe182c95c67228dc7feb9fdffde0-new_light_btn_scenes_ripple_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/60b75e596a5a1866ea8bdad73dbc9043-new_light_btn_scenes_ripple_dark%403x.png"
+            ],
+            "sceneName": "Ripple",
+            "analyticName": "Ripple",
+            "sceneType": 2,
+            "sceneCode": 204,
+            "scenceCategoryId": 5,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 128,
+                "scenceName": "",
+                "scenceParam": "AyNQAQAZAgH/CgIAAAACAAAE////Qv//AKD/ALX/FgH9AAAAACNVAQAZAgH/CgIAAAACAAAE////Qv//AKD/ALX/FAH9AAAAABoAAQAAAAEUFAAAAAAAAP8BgP//AAAAAAAAAA==",
+                "sceneCode": 204,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11251,
+                    "scenceParam": "AyNQAQAZAgH/CgIAAAACAAAE////Qv//AKD/ALX/FgH9AAAAACNVAQAZAgH/CgIAAAACAAAE////Qv//AKD/ALX/FAH9AAAAABoAAQAAAAEUFAAAAAAAAP8BgP//AAAAAAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\":[226,242,249,252],\"defaultIndex\":2,\"page\":0},{\"page\":1,\"defaultIndex\":2,\"moveIn\":[226,242,249,252]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31251,
+                    "scenceParam": "AyNQAQAZAgH/CgIAAAACAAAE////Qv//AKD/ALX/FgH9AAAAACNVAQAZAgH/CgIAAAACAAAE////Qv//AKD/ALX/FAH9AAAAABoAAQAAAAEUFAAAAAAAAP8BgP//AAAAAAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\": [226, 242, 249, 252], \"defaultIndex\": 3, \"page\": 0}, {\"page\": 1, \"defaultIndex\": 3, \"moveIn\": [226, 242, 249, 252]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 147,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/408ab6a892d9a87149986dacf5d0d747-new_light_btn_scenes_sea_wave%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/6046fe2de59ff1d382aaa25f3b7ae5b6-new_light_btn_scenes_sea_wave_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/8384b497c969ed95108c127c29354fab-new_light_btn_scenes_sea_wave_dark%403x.png"
+            ],
+            "sceneName": "Wave",
+            "analyticName": "Wave",
+            "sceneType": 2,
+            "sceneCode": 227,
+            "scenceCategoryId": 5,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 129,
+                "scenceName": "A",
+                "scenceParam": "ASMAAAACAAH//wAAAAAC/TIEAAD/AH7/AOz/AAD/EwH8AAAAAA==",
+                "sceneCode": 227,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11252,
+                    "scenceParam": "ASMAAAACAAH//wAAAAAC/TIEAAD/AH7/AOz/AAD/EwH8AAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"color\":[237,247,253],\"page\":0,\"moveIn\":[242,249,252],\"defaultIndex\":2}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31252,
+                    "scenceParam": "ASMAAAACAAH//wAAAAAC/TIEAAD/AH7/AOz/AAD/EwH8AAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"color\": [242, 252, 255], \"page\": 0, \"moveIn\": [242, 249, 252], \"defaultIndex\": 3}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 2881,
+                "scenceName": "B",
+                "scenceParam": "Ax1VAAABAAH//wAAFBQA9wUC/wf9AP//FgD8AwJwAB1QAAABAAH//wAAFBQA9wUC/wf/AP//FAD8AwJwABoAAAABAAFBQQAAFBQAgBQB/6N4AACAAACAAA==",
+                "sceneCode": 2498,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11253,
+                    "scenceParam": "Ax1VAAABAAH//wAAFBQA9wUC/wf9AP//FgD8AwJwAB1QAAABAAH//wAAFBQA9wUC/wf/AP//FAD8AwJwABoAAAABAAFBQQAAFBQAgBQB/6N4AACAAACAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\":[242,249,252,255],\"color\":[239,247,247,252],\"page\":0,\"defaultIndex\":2},{\"moveIn\":[242,249,252,255],\"color\":[242,247,247,252],\"page\":1,\"defaultIndex\":2}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31253,
+                    "scenceParam": "Ax1VAAABAAH//wAAFBQA9wUC/wf9AP//FgD8AwJwAB1QAAABAAH//wAAFBQA9wUC/wf/AP//FAD8AwJwABoAAAABAAFBQQAAFBQAgBQB/6N4AACAAACAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\": [242, 249, 252, 255], \"color\": [239, 247, 247, 252], \"page\": 0, \"defaultIndex\": 3}, {\"moveIn\": [242, 249, 252, 255], \"color\": [242, 247, 247, 252], \"page\": 1, \"defaultIndex\": 3}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 148,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/0a3600c4331a941785e8e4b9c7f28981-new_light_btn_scenes_deep_ocean%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/dd91a7b3fa574ef8e81ef524664e58c9-new_light_btn_scenes_deep_ocean_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/77ec9fdce5498d175c8c06b88fe18dae-new_light_btn_scenes_deep_ocean_dark%403x.png"
+            ],
+            "sceneName": "Deep sea",
+            "analyticName": "Deep sea",
+            "sceneType": 2,
+            "sceneCode": 203,
+            "scenceCategoryId": 5,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 130,
+                "scenceName": "",
+                "scenceParam": "Ah0AAAABAAH//wAAAAAA3DICAGT/AAD/AAAAAAAAABoAAgoBAgH/KAHXAAAAADIBAP+WAAAAAAAAAA==",
+                "sceneCode": 203,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 217,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/22a71273bd01620d2d5095805cbb6a64-new_light_btn_scenes_desert%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/1391f99fd4140976565c986446d8e5e4-new_light_btn_scenes_desert_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/d031b536ad574eea9bd3df1eb07e23a3-new_light_btn_scenes_desert_dark%403x.png"
+            ],
+            "sceneName": "Desert",
+            "analyticName": "Desert",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 197,
+                "scenceName": "",
+                "scenceParam": "AhoAAQAyAgH/GQEAFBQA/TIByHgAAwCAAAAAACkAAh4PAAH/MgDIFBQA+gAG//8A/28A/6AA/3MA/8IA+v8AFAH9AAD/AA==",
+                "sceneCode": 2006,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11254,
+                    "scenceParam": "AhoAAQAyAgH/GQEAFBQA/TIByHgAAwCAAAAAACkAAh4PAAH/MgDIFBQA+gAG//8A/28A/6AA/3MA/8IA+v8AFAH9AAD/AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":0,\"moveIn\":[244,249,252],\"color\":[250,252,252],\"page\":1}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31254,
+                    "scenceParam": "AhoAAQAyAgH/GQEAFBQA/TIByHgAAwCAAAAAACkAAh4PAAH/MgDIFBQA+gAG//8A/28A/6AA/3MA/8IA+v8AFAH9AAD/AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\": 1, \"moveIn\": [244, 249, 252], \"color\": [255, 255, 255], \"page\": 1}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 218,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/4041497fbd8aa805ae136c908fc5de77-new_light_btn_scenes_karst%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/6409e4614e680f44fa9266daeca4c9d5-new_light_btn_scenes_karst_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/7214d42eed26f1effca53b36308a8b2d-new_light_btn_scenes_karst_dark%403x.png"
+            ],
+            "sceneName": "Karst Cave",
+            "analyticName": "Karst Cave",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 198,
+                "scenceName": "A",
+                "scenceParam": "AyYAAQAKAgH/GQFkCgoCyBQFvQD//0kA/5YAnv8AFP//FgFkAAAAACkAAh4PAgH/ZAHmAAAB+hQGBP8AAP8AiwD//0v/8QAe//8AAAAAAAAAACAAAAABAAGWMgDmFBQC+hQDAMz/AG7/AAP/AAAAAAAAAA==",
+                "sceneCode": 2007,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11255,
+                    "scenceParam": "AyYAAQAKAgH/GQFkCgoCyBQFvQD//0kA/5YAnv8AFP//FgFkAAAAACkAAh4PAgH/ZAHmAAAB+hQGBP8AAP8AiwD//0v/8QAe//8AAAAAAAAAACAAAAABAAGWMgDmFBQC+hQDAMz/AG7/AAP/AAAAAAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\":1,\"defaultIndex\":1,\"color\":[211,224,221],\"bright\":[{\"brightValue\":[204,204,211],\"brightPage\":\"0\"}]},{\"defaultIndex\":1,\"page\":2,\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[204,216,211]}],\"color\":[206,216,229]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31255,
+                    "scenceParam": "AyYAAQAKAgH/GQFkCgoCyBQFvQD//0kA/5YAnv8AFP//FgFkAAAAACkAAh4PAgH/ZAHmAAAB+hQGBP8AAP8AiwD//0v/8QAe//8AAAAAAAAAACAAAAABAAGWMgDmFBQC+hQDAMz/AG7/AAP/AAAAAAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\": 1, \"defaultIndex\": 2, \"color\": [216, 229, 226], \"bright\": [{\"brightValue\": [204, 214, 211], \"brightPage\": \"0\"}]}, {\"defaultIndex\": 2, \"page\": 2, \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [204, 226, 211]}], \"color\": [211, 221, 234]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 231,
+                "scenceName": "B",
+                "scenceParam": "ASkAAAAyAgH/AAH/UmQC4mQGiwD//wAA/38AAP8AAAD///8AER7jER7iBQ==",
+                "sceneCode": 2024,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 2885,
+                "scenceName": "C",
+                "scenceParam": "BSkyAAABAgE4AAP/BhMAmRQG/wAA/38A//8AAP8AAAD/iwD/EgD6AACAAClgAAABAgF1AAP/BhMA/hQGiwD/AAD/AP8A//8A/38A/wAAEgD9AACAACk1AAABAgE5AAP/BhMAzBQGiwD/AAD/AP8A//8A/38A/wAAEAD6AgCAAClkAAABAgF1AAP/BhMA9xQG/wAA/38A//8AAP8AAAD/iwD/EAD9AACAACkkAAABAgEOAAP/BhMAzRQG/wAA//8AAAD//38AAP8AiwD/AACAAACAAA==",
+                "sceneCode": 2502,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11256,
+                    "scenceParam": "BSkyAAABAgE4AAP/BhMAmRQG/wAA/38A//8AAP8AAAD/iwD/EgD6AACAAClgAAABAgF1AAP/BhMA/hQGiwD/AAD/AP8A//8A/38A/wAAEgD9AACAACk1AAABAgE5AAP/BhMAzBQGiwD/AAD/AP8A//8A/38A/wAAEAD6AgCAAClkAAABAgF1AAP/BhMA9xQG/wAA/38A//8AAP8AAAD/iwD/EAD9AACAACkkAAABAgEOAAP/BhMAzRQG/wAA//8AAAD//38AAP8AiwD/AACAAACAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\":0,\"defaultIndex\":2,\"moveIn\":[234,242,250,252]},{\"defaultIndex\":2,\"moveIn\":[237,244,253,253],\"page\":1,\"color\":[247,254,254,254]},{\"defaultIndex\":2,\"moveIn\":[234,242,250,252],\"page\":2},{\"moveIn\":[237,244,253,253],\"page\":3,\"defaultIndex\":2,\"color\":[237,247,247,247]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31256,
+                    "scenceParam": "BSkyAAABAgE4AAP/BhMAmRQG/wAA/38A//8AAP8AAAD/iwD/EgD6AACAAClgAAABAgF1AAP/BhMA/hQGiwD/AAD/AP8A//8A/38A/wAAEgD9AACAACk1AAABAgE5AAP/BhMAzBQGiwD/AAD/AP8A//8A/38A/wAAEAD6AgCAAClkAAABAgF1AAP/BhMA9xQG/wAA/38A//8AAP8AAAD/iwD/EAD9AACAACkkAAABAgEOAAP/BhMAzRQG/wAA//8AAAD//38AAP8AiwD/AACAAACAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\": 0, \"defaultIndex\": 3, \"moveIn\": [234, 242, 250, 252]}, {\"defaultIndex\": 3, \"moveIn\": [237, 244, 253, 253], \"page\": 1, \"color\": [247, 254, 254, 254]}, {\"defaultIndex\": 3, \"moveIn\": [234, 242, 250, 252], \"page\": 2}, {\"moveIn\": [237, 244, 253, 253], \"page\": 3, \"defaultIndex\": 3, \"color\": [237, 247, 247, 247]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 219,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/9a37287a548e6fdf8a2f5f0778882feb-new_light_btn_scenes_glacier%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/f12669c3f805fe8ccb8e33190f82f042-new_light_btn_scenes_glacier_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/ff358aa5aa88373858a4c2ecec5335a4-new_light_btn_scenes_glacier_dark%403x.png"
+            ],
+            "sceneName": "Glacier",
+            "analyticName": "Glacier",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 199,
+                "scenceName": "",
+                "scenceParam": "BCBQAQAZAAH/AAD/MjICZAADAAD/AP//////FgD/AAAAACBVAQAZAAH/AAD/MjICZAADAAD/AP//////FAD/AAAAACkAAh4FAAH/AAL/MjIC/xQGAP//AAAA////AAAA////AP//AAAAEgD6ACYAAh4FAAH/AAL/MjIC3AIFAP//AAAA////AAAAAP//AAAAEgDrAA==",
+                "sceneCode": 2008,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11257,
+                    "scenceParam": "BCBQAQAZAAH/AAD/MjICZAADAAD/AP//////FgD/AAAAACBVAQAZAAH/AAD/MjICZAADAAD/AP//////FAD/AAAAACkAAh4FAAH/AAL/MjIC/xQGAP//AAAA////AAAA////AP//AAAAEgD6ACYAAh4FAAH/AAL/MjIC3AIFAP//AAAA////AAAAAP//AAAAEgDrAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":1,\"moveIn\":[244,252,252],\"bright\":[{\"brightValue\":[244,244,249],\"brightPage\":\"0\"}],\"page\":0},{\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[244,244,249]}],\"defaultIndex\":1,\"moveIn\":[244,252,252],\"page\":1},{\"defaultIndex\":1,\"moveAll\":[234,242,249],\"color\":[234,242,242],\"page\":2},{\"page\":3,\"moveAll\":[226,235,252],\"color\":[220,220,232],\"defaultIndex\":1,\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[204,204,232]}]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31257,
+                    "scenceParam": "BCBQAQAZAAH/AAD/MjICZAADAAD/AP//////FgD/AAAAACBVAQAZAAH/AAD/MjICZAADAAD/AP//////FAD/AAAAACkAAh4FAAH/AAL/MjIC/xQGAP//AAAA////AAAA////AP//AAAAEgD6ACYAAh4FAAH/AAL/MjIC3AIFAP//AAAA////AAAAAP//AAAAEgDrAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\": 2, \"moveIn\": [244, 252, 252], \"bright\": [{\"brightValue\": [244, 254, 249], \"brightPage\": \"0\"}], \"page\": 0}, {\"bright\": [{\"brightPage\": \"0\", \"brightValue\": [244, 254, 249]}], \"defaultIndex\": 2, \"moveIn\": [244, 252, 252], \"page\": 1}, {\"defaultIndex\": 2, \"moveAll\": [234, 252, 249], \"color\": [239, 247, 247], \"page\": 2}, {\"page\": 3, \"moveAll\": [226, 245, 252], \"color\": [225, 225, 237], \"defaultIndex\": 2, \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [204, 214, 232]}]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 220,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/0069d330985013103eb1736da042236b-new_light_btn_scenes_gobi%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/f9d56b5e5e958b683de7192555ebcc08-new_light_btn_scenes_gobi_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/072aec348b6fde860714dcb543092b5c-new_light_btn_scenes_gobi_dark%403x.png"
+            ],
+            "sceneName": "Gobi Desert",
+            "analyticName": "Gobi Desert",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 200,
+                "scenceName": "",
+                "scenceParam": "AiCgAQAyAAGWlgAAAAAA3BQDljIAyDwA0jIAAAAAAAAAAB0AAgUBAAH/FAHwFFAC+kYC/38A/7QAAAAAAAAAAA==",
+                "sceneCode": 2009,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 221,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/3b036e15899311501ceda23da187762f-new_light_btn_scenes_moonlight%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/2d34f9407d3f4931819d048d40a98b39-new_light_btn_scenes_moonlight_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/c874bd9ec0de6f93a742cbf77917b12e-new_light_btn_scenes_moonlight_dark%403x.png"
+            ],
+            "sceneName": "Moonlight",
+            "analyticName": "Moonlight",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 201,
+                "scenceName": "A",
+                "scenceParam": "AiBgAgoFAgFkZABkAAAC/RQD//8A//+g////AAAAEAXcAB2gAQAyAAFkHgAAAAAA/RQCAABQAB6gAAAAAAAAAA==",
+                "sceneCode": 2010,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 232,
+                "scenceName": "B",
+                "scenceParam": "BB0AAQAyAAHOZwNqFBQBABQC////AAAAAACAAAD1AB0AAQAyAAH/lgH8FBQBABQCAAAA/4EAAACAAAD0ABoQAQABAAH/AAN+LWkBABQB////AACAEAD6ABoQAQABAAH/AANkLXABABQB/0kHAACAEAD5AA==",
+                "sceneCode": 2025,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 222,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/0ab6b5249437e9d0aea7e45ca9433804-new_light_btn_scenes_cornfield%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/e07b01a769700d32fa5528b806ff569f-new_light_btn_scenes_cornfield_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/5bb03f6ac5e707745b65b01362dc8b92-new_light_btn_scenes_cornfield_dark%403x.png"
+            ],
+            "sceneName": "Cornfield",
+            "analyticName": "Cornfield",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 202,
+                "scenceName": "",
+                "scenceParam": "Bh0gAQAIAgH/AAD/FBQA/xQC/0EA/4IAEQDyAAAAAB0iAQAIAgH/AAD/FBQA/xQC/0EA/2MAEQDyAAAAAB0kAQAIAgH/AAD/FBQA/xQC/0EA/2MAEQDyAAAAAB0mAQAIAgH/AAD/FBQA/xQC/0EA/5YAEQDyAAAAAB0oAQAIAgH/AAD/FBQA/xQC/0EA/2MAEQDyAAAAABqgAQAyAAFkCgAAAAAA/zIBPCMAERTwAAAAAA==",
+                "sceneCode": 2011,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11258,
+                    "scenceParam": "Bh0gAQAIAgH/AAD/FBQA/xQC/0EA/4IAEQDyAAAAAB0iAQAIAgH/AAD/FBQA/xQC/0EA/2MAEQDyAAAAAB0kAQAIAgH/AAD/FBQA/xQC/0EA/2MAEQDyAAAAAB0mAQAIAgH/AAD/FBQA/xQC/0EA/5YAEQDyAAAAAB0oAQAIAgH/AAD/FBQA/xQC/0EA/2MAEQDyAAAAABqgAQAyAAFkCgAAAAAA/zIBPCMAERTwAAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\":[226,242,249],\"color\":[242,247,249],\"page\":0,\"defaultIndex\":1},{\"defaultIndex\":1,\"page\":1,\"color\":[242,247,249],\"moveIn\":[226,242,249]},{\"moveIn\":[226,242,249],\"defaultIndex\":1,\"page\":2,\"color\":[242,247,249]},{\"defaultIndex\":1,\"color\":[242,247,249],\"moveIn\":[226,242,249],\"page\":3},{\"color\":[242,247,249],\"moveIn\":[226,242,249],\"defaultIndex\":1,\"page\":4}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31258,
+                    "scenceParam": "Bh0gAQAIAgH/AAD/FBQA/xQC/0EA/4IAEQDyAAAAAB0iAQAIAgH/AAD/FBQA/xQC/0EA/2MAEQDyAAAAAB0kAQAIAgH/AAD/FBQA/xQC/0EA/2MAEQDyAAAAAB0mAQAIAgH/AAD/FBQA/xQC/0EA/5YAEQDyAAAAAB0oAQAIAgH/AAD/FBQA/xQC/0EA/2MAEQDyAAAAABqgAQAyAAFkCgAAAAAA/zIBPCMAERTwAAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\": [226, 252, 249], \"color\": [247, 252, 254], \"page\": 0, \"defaultIndex\": 2}, {\"defaultIndex\": 2, \"page\": 1, \"color\": [247, 252, 254], \"moveIn\": [226, 252, 249]}, {\"moveIn\": [226, 252, 249], \"defaultIndex\": 2, \"page\": 2, \"color\": [247, 252, 254]}, {\"defaultIndex\": 2, \"color\": [247, 252, 254], \"moveIn\": [226, 252, 249], \"page\": 3}, {\"color\": [247, 252, 254], \"moveIn\": [226, 252, 249], \"defaultIndex\": 2, \"page\": 4}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 223,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/99eb7a7615e2219d361d2482ec07cb2d-new_light_btn_scenes_huahai%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/b180d6641badbe961bdbdcdb90cd374b-new_light_btn_scenes_huahai_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/58793e611dc304a9d81b752a4d6f6684-new_light_btn_scenes_huahai_dark%403x.png"
+            ],
+            "sceneName": "Flower Field",
+            "analyticName": "Flower Field",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 203,
+                "scenceName": "A",
+                "scenceParam": "AiygAh4ZAgH/lgDSAAAC/gAH0QBe/wMA/2wA//8A/38A/wAA9QD/AAAAEADwABqgAQAyAAEyFAAAAAAA+hQBzwBiAAAAAAAAAA==",
+                "sceneCode": 2012,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11259,
+                    "scenceParam": "AiygAh4ZAgH/lgDSAAAC/gAH0QBe/wMA/2wA//8A/38A/wAA9QD/AAAAEADwABqgAQAyAAEyFAAAAAAA+hQBzwBiAAAAAAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveAll\":[201,216,219],\"color\":[209,224,224],\"defaultIndex\":1,\"page\":0,\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[198,204,206]}]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31259,
+                    "scenceParam": "AiygAh4ZAgH/lgDSAAAC/gAH0QBe/wMA/2wA//8A/38A/wAA9QD/AAAAEADwABqgAQAyAAEyFAAAAAAA+hQBzwBiAAAAAAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveAll\": [201, 226, 219], \"color\": [214, 229, 229], \"defaultIndex\": 2, \"page\": 0, \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [198, 214, 206]}]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 1767,
+                "scenceName": "B",
+                "scenceParam": "BR0gAAABAAH//wCAFBQD9gECAAD//wAAEAD7AAD8AB0iAAABAAH//wCAFBQD9gECAP//AP8AEAD7AAD8AB0kAAABAAH//wCAFBQD9gECiwD//38AEAD7AAD8AB0mAAABAAH//wCAFBQD9gECAP8A//8AEAD7AAD8AB0oAAABAAH//wCAFBQD9gECiwD/AP//EAD7AAD8AA==",
+                "sceneCode": 2285,
+                "specialEffect": [],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 224,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/ae75eec27fb615dbe32a55b11b1a0913-new_light_btn_scenes_volcanic%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/304a761e94f9795cea1dcba7bdd9de99-new_light_btn_scenes_volcanic_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/832244f0704106161b074840dde2a1d4-new_light_btn_scenes_volcanic_dark%403x.png"
+            ],
+            "sceneName": "Volcano",
+            "analyticName": "Volcano",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 204,
+                "scenceName": "A",
+                "scenceParam": "BSNQAQAPAgH/CgD6AAACAAAE/wAAyAAAlgAAMgAAFgH/AAAAACNVAQAPAgH/CgD6AAACAAAE/wAAyAAAlgAAMgAAFAH/AAAAACNVAQAPAgH/CgD6AAACAAAE/wAAyAAAlgAAMgAAFAH/AAAAACNQAQAPAgH/CgD6AAACAAAE/wAAyAAAlgAAMgAAFgH/AAAAAB2gAh4PAgH/CgD/AAACAAACMgAA/wAAEADJAAAAAA==",
+                "sceneCode": 2013,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11260,
+                    "scenceParam": "BSNQAQAPAgH/CgD6AAACAAAE/wAAyAAAlgAAMgAAFgH/AAAAACNVAQAPAgH/CgD6AAACAAAE/wAAyAAAlgAAMgAAFAH/AAAAACNVAQAPAgH/CgD6AAACAAAE/wAAyAAAlgAAMgAAFAH/AAAAACNQAQAPAgH/CgD6AAACAAAE/wAAyAAAlgAAMgAAFgH/AAAAAB2gAh4PAgH/CgD/AAACAAACMgAA/wAAEADJAAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\":[244,249,252],\"bright\":[{\"brightValue\":[244,250,250],\"brightPage\":\"0\"}],\"page\":0,\"defaultIndex\":1},{\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[244,250,252]}],\"defaultIndex\":1,\"page\":1,\"moveIn\":[244,249,252]},{\"bright\":[{\"brightValue\":[244,250,252],\"brightPage\":\"0\"}],\"page\":2,\"moveIn\":[239,247,252],\"defaultIndex\":1},{\"moveIn\":[239,247,252],\"bright\":[{\"brightValue\":[244,250,252],\"brightPage\":\"0\"}],\"defaultIndex\":1,\"page\":3},{\"moveIn\":[201,201,211],\"bright\":[{\"brightValue\":[198,206,206],\"brightPage\":\"0\"}],\"defaultIndex\":1,\"page\":4}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31260,
+                    "scenceParam": "BSNQAQAPAgH/CgD6AAACAAAE/wAAyAAAlgAAMgAAFgH/AAAAACNVAQAPAgH/CgD6AAACAAAE/wAAyAAAlgAAMgAAFAH/AAAAACNVAQAPAgH/CgD6AAACAAAE/wAAyAAAlgAAMgAAFAH/AAAAACNQAQAPAgH/CgD6AAACAAAE/wAAyAAAlgAAMgAAFgH/AAAAAB2gAh4PAgH/CgD/AAACAAACMgAA/wAAEADJAAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\": [244, 249, 252], \"bright\": [{\"brightValue\": [244, 250, 250], \"brightPage\": \"0\"}], \"page\": 0, \"defaultIndex\": 2}, {\"bright\": [{\"brightPage\": \"0\", \"brightValue\": [244, 250, 252]}], \"defaultIndex\": 2, \"page\": 1, \"moveIn\": [244, 249, 252]}, {\"bright\": [{\"brightValue\": [244, 250, 252], \"brightPage\": \"0\"}], \"page\": 2, \"moveIn\": [239, 247, 252], \"defaultIndex\": 2}, {\"moveIn\": [239, 247, 252], \"bright\": [{\"brightValue\": [244, 250, 252], \"brightPage\": \"0\"}], \"defaultIndex\": 2, \"page\": 3}, {\"moveIn\": [201, 211, 211], \"bright\": [{\"brightValue\": [198, 216, 206], \"brightPage\": \"0\"}], \"defaultIndex\": 2, \"page\": 4}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 233,
+                "scenceName": "B",
+                "scenceParam": "BSYwAQAPAgH/AAD/FBQB/w8F/wAAAAAA/ysGAAAA/1EHEgD1AADUACY3AQAPAgH/AAD/FBQB/w8F/wAAAAAA/yoHAAAA/1kHEAD1AADUAB1DAQASAAH/GgD/FBQB0w8C/wAA/xEHEQD4AADUAB0lAAABAgGyDQDTGRkA0w8C/0UH/wAAEAD4AADUAB0jAAABAgGyDADTGRkA0w8C/zoH/wAAEgD4AADUAA==",
+                "sceneCode": 2026,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11261,
+                    "scenceParam": "BSYwAQAPAgH/AAD/FBQB/w8F/wAAAAAA/ysGAAAA/1EHEgD1AADUACY3AQAPAgH/AAD/FBQB/w8F/wAAAAAA/yoHAAAA/1kHEAD1AADUAB1DAQASAAH/GgD/FBQB0w8C/wAA/xEHEQD4AADUAB0lAAABAgGyDQDTGRkA0w8C/0UH/wAAEAD4AADUAB0jAAABAgGyDADTGRkA0w8C/zoH/wAAEgD4AADUAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":1,\"moveIn\":[237,245,252],\"color\":[252,255,255],\"bright\":[{\"brightValue\":[249,255,255],\"brightPage\":\"0\"}],\"page\":0},{\"defaultIndex\":1,\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[249,255,255]}],\"color\":[252,255,255],\"moveIn\":[237,245,252],\"page\":1},{\"page\":2,\"moveIn\":[239,248,252],\"defaultIndex\":1,\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[204,209,209]}]},{\"moveIn\":[239,248,252],\"page\":3,\"defaultIndex\":1},{\"page\":4,\"moveIn\":[239,248,252],\"defaultIndex\":1}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31261,
+                    "scenceParam": "BSYwAQAPAgH/AAD/FBQB/w8F/wAAAAAA/ysGAAAA/1EHEgD1AADUACY3AQAPAgH/AAD/FBQB/w8F/wAAAAAA/yoHAAAA/1kHEAD1AADUAB1DAQASAAH/GgD/FBQB0w8C/wAA/xEHEQD4AADUAB0lAAABAgGyDQDTGRkA0w8C/0UH/wAAEAD4AADUAB0jAAABAgGyDADTGRkA0w8C/zoH/wAAEgD4AADUAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\": 2, \"moveIn\": [237, 245, 252], \"color\": [255, 255, 255], \"bright\": [{\"brightValue\": [249, 255, 255], \"brightPage\": \"0\"}], \"page\": 0}, {\"defaultIndex\": 2, \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [249, 255, 255]}], \"color\": [255, 255, 255], \"moveIn\": [237, 245, 252], \"page\": 1}, {\"page\": 2, \"moveIn\": [239, 248, 252], \"defaultIndex\": 2, \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [204, 219, 209]}]}, {\"moveIn\": [239, 248, 252], \"page\": 3, \"defaultIndex\": 2}, {\"page\": 4, \"moveIn\": [239, 248, 252], \"defaultIndex\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 376,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/4c728c962a49a1d4d0cc22e95ee2bb43-new_light_btn_scenes_baoyu.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/487cba8c9beba4449e4000f862adbaed-new_light_btn_scenes_baoyu_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/419a91351f6db513ede6e25bccc8bd03-new_light_btn_scenes_baoyu_dark.png"
+            ],
+            "sceneName": "Downpour",
+            "analyticName": "Downpour",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 2,
+            "scenesHint": "Those with epilepsy may experience discomfort when using this Scene mode. Exercise caution during use.",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 394,
+                "scenceName": "",
+                "scenceParam": "BCMwAgQBAAH/AAL/AgIA/2QE////AAAAAAAAAAAAAACAEQD0ACkUAgIBAAH/AAD/AQQA/yYGAAAAAAAA////AAAA////AAAAAACAEwDfAC9CAgUDAAL/AAL/AgH/AAD7KMgA/x4GAAAAAAAAAAAAAAAA////AAAAAACAAACAACAAAAAyAgIHAgGbgMgEAwOZfMAAgBQB////AACAAACAAA==",
+                "sceneCode": 2127,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 378,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/2a835de4a91fa4b8d13d3aafec4dee56-new_light_btn_scenes_qingtian.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/d940e21c4e9ab91b878e96cc4e6656ed-new_light_btn_scenes_qingtian_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/12ecd7c525e60fff6372f3577f8649e6-new_light_btn_scenes_qingtian_dark.png"
+            ],
+            "sceneName": "Sunny",
+            "analyticName": "Sunny",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 396,
+                "scenceName": "A",
+                "scenceParam": "Ax0AAAABAAHxwwB/FBQAkgICAP//AAD/AAB/AAB/AR0AAhkBAAHxwwDKFBQAfxQC////AAAAAAB/EQD8AR0AAhkBAAHxwwDKFBQAfxQC////AAAAAAB/EwD8AQ==",
+                "sceneCode": 2129,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 430,
+                "scenceName": "B",
+                "scenceParam": "Ax0AAAABAAH//wB/FBQAfxQC//8A/+cAAAB/AAB/ARoAAgcEAAH//wABFBQA+BQBxf/9AAB/EADxAhoAAgcEAAH//wABFBQA+BQBKsn/AAB/EgDxAg==",
+                "sceneCode": 2159,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          }
+        ]
+      },
+      {
+        "categoryId": 6,
+        "categoryName": "Festival",
+        "scenes": [
+          {
+            "sceneId": 149,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/d8869591e386312a48d7786e7d568b40-new_light_btn_scenes_new_year%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/16a809090308f7537d6cec951777e35b-new_light_btn_scenes_new_year_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/4cb0c899ec4ef950bffeb3e0772639ad-new_light_btn_scenes_new_year_dark%403x.png"
+            ],
+            "sceneName": "New Years",
+            "analyticName": "New Years",
+            "sceneType": 2,
+            "sceneCode": 222,
+            "scenceCategoryId": 6,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 131,
+                "scenceName": "",
+                "scenceParam": "BSCgAQAKAgH/CgIAAAACAAADAKr/AP//////AAD6EAH8ACCiAQAKAgH/CgIAAAACAAADiwD/uwD//zv/AAD6EAH8ACCkAQAKAgH/CgIAAAACAAAD/wAA/zxQ////AAD6EAH8ACCmAQAKAgH/CgIAAAACAAADAP8AaP8AuP8AAAD6EAH8ACCoAQAKAgH/CgIAAAACAAAD/38A/8QA9P8AAAD6EAH8AA==",
+                "sceneCode": 222,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11262,
+                    "scenceParam": "BSCgAQAKAgH/CgIAAAACAAADAKr/AP//////EAD6AAH3ACCiAQAKAgH/CgIAAAACAAADiwD/uwD//zv/EAD6AAH3ACCkAQAKAgH/CgIAAAACAAAD/wAA/zxQ////EAD6AAH3ACCmAQAIAgH/CgIAAAACAAADAP8AaP8AuP8AEAD6AAH3ACCoAQAEAgH/CgIAAAACAAAD/38A/8QA9P8AFAD6AAH3AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":1,\"moveIn\":[242,250,252],\"page\":0},{\"moveIn\":[242,250,252],\"page\":1,\"defaultIndex\":1},{\"moveIn\":[242,250,252],\"defaultIndex\":1,\"page\":2},{\"defaultIndex\":1,\"moveIn\":[242,250,255],\"page\":3},{\"moveIn\":[242,250,255],\"page\":4,\"defaultIndex\":1}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31262,
+                    "scenceParam": "BSCgAQAKAgH/CgIAAAACAAADAKr/AP//////EAD6AAH3ACCiAQAKAgH/CgIAAAACAAADiwD/uwD//zv/EAD6AAH3ACCkAQAKAgH/CgIAAAACAAAD/wAA/zxQ////EAD6AAH3ACCmAQAIAgH/CgIAAAACAAADAP8AaP8AuP8AEAD6AAH3ACCoAQAEAgH/CgIAAAACAAAD/38A/8QA9P8AFAD6AAH3AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\": 2, \"moveIn\": [242, 250, 252], \"page\": 0}, {\"moveIn\": [242, 250, 252], \"page\": 1, \"defaultIndex\": 2}, {\"moveIn\": [242, 250, 252], \"defaultIndex\": 2, \"page\": 2}, {\"defaultIndex\": 2, \"moveIn\": [242, 250, 255], \"page\": 3}, {\"moveIn\": [242, 250, 255], \"page\": 4, \"defaultIndex\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 150,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/4b638c2c79413589e4d24e167bd4d698-new_light_btn_scenes_christmas%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/1b39f49fcf816d4fedd5009ddb223960-new_light_btn_scenes_christmas_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/1e782af903c0f18d6cec9208cdaea638-new_light_btn_scenes_christmas_dark%403x.png"
+            ],
+            "sceneName": "Christmas",
+            "analyticName": "Christmas",
+            "sceneType": 2,
+            "sceneCode": 221,
+            "scenceCategoryId": 6,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 132,
+                "scenceName": "A",
+                "scenceParam": "AykAAgoFAgH/GQAAAAAC+jIG/zgA/38AAP8AAAAAAP///wAAFAH6AAAAACMAAg8DAAH/GQHmMjIB+jIE8QAdAP8AAP//////FgH6EgHcACAAAAABAgH/AAD+FBQA/xQD/wAAAAAAAP8AEQCAAAAAAA==",
+                "sceneCode": 221,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11263,
+                    "scenceParam": "AykAAgoFAgH/GQAAAAAC+jIG/zgA/38AAP8AAAAAAP///wAAFAH6AAAAACMAAg8DAAH/GQHmMjIB+jIE8QAdAP8AAP//////FgH6EgHcACAAAAABAgH/AAD+FBQA/xQD/wAAAAAAAP8AEQCAAAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\":0,\"color\":[244,250,252],\"defaultIndex\":1,\"moveIn\":[242,249,252]},{\"color\":[239,244,249],\"page\":1,\"defaultIndex\":1,\"moveIn\":[242,249,252],\"moveAll\":[226,234,247],\"bright\":[{\"brightValue\":[230,230,234],\"brightPage\":\"0\"}]},{\"defaultIndex\":1,\"page\":2,\"color\":[242,247,247]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31263,
+                    "scenceParam": "AykAAgoFAgH/GQAAAAAC+jIG/zgA/38AAP8AAAAAAP///wAAFAH6AAAAACMAAg8DAAH/GQHmMjIB+jIE8QAdAP8AAP//////FgH6EgHcACAAAAABAgH/AAD+FBQA/xQD/wAAAAAAAP8AEQCAAAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\": 0, \"color\": [249, 255, 255], \"defaultIndex\": 2, \"moveIn\": [242, 249, 252]}, {\"color\": [244, 249, 254], \"page\": 1, \"defaultIndex\": 2, \"moveIn\": [242, 249, 252], \"moveAll\": [226, 244, 247], \"bright\": [{\"brightValue\": [230, 240, 234], \"brightPage\": \"0\"}]}, {\"defaultIndex\": 2, \"page\": 2, \"color\": [247, 252, 252]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 234,
+                "scenceName": "B",
+                "scenceParam": "AikAAQAyAAH//wGAFBQB/QEG/wAAAAAAAAAAAAAAAAAAAAAAFAD9EACAASkAAQAyAAH//wGAFBQB/QEGAAAAAAAAAAAAAP8AAAAAAAAAFgD9EgCAAQ==",
+                "sceneCode": 2027,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11264,
+                    "scenceParam": "AikAAQAyAAH//wGAFBQB/QEG/wAAAAAAAAAAAAAAAAAAAAAAFAD9EACAASkAAQAyAAH//wGAFBQB/QEGAAAAAAAAAAAAAP8AAAAAAAAAFgD9EgCAAQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"color\":[249,253,253],\"moveIn\":[244,252,252],\"moveAll\":[128,128,252],\"page\":0,\"defaultIndex\":1},{\"page\":1,\"defaultIndex\":1,\"moveIn\":[244,252,252],\"color\":[249,253,253],\"moveAll\":[128,128,252]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31264,
+                    "scenceParam": "AikAAQAyAAH//wGAFBQB/QEG/wAAAAAAAAAAAAAAAAAAAAAAFAD9EACAASkAAQAyAAH//wGAFBQB/QEGAAAAAAAAAAAAAP8AAAAAAAAAFgD9EgCAAQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"color\": [254, 255, 255], \"moveIn\": [244, 252, 252], \"moveAll\": [128, 138, 252], \"page\": 0, \"defaultIndex\": 2}, {\"page\": 1, \"defaultIndex\": 2, \"moveIn\": [244, 252, 252], \"color\": [254, 255, 255], \"moveAll\": [128, 138, 252]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 151,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/e57e46e0c2ac5c2945f6ff054e8f9ee1-new_light_btn_scenes_halloween%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/76b6f8b7bb34cea5f9497620dd0da49f-new_light_btn_scenes_halloween_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/b3a3807ff048ce1c3b159a20ab90d5ce-new_light_btn_scenes_halloween_dark%403x.png"
+            ],
+            "sceneName": "Halloween",
+            "analyticName": "Halloween",
+            "sceneType": 1,
+            "sceneCode": 110,
+            "scenceCategoryId": 6,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 133,
+                "scenceName": "A",
+                "scenceParam": "gwb/9QAFAP///wUA/+n/BQD///8FAP/p2QUA//j/BgAE/x4A/1oA/zIA/3gA",
+                "sceneCode": 110,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 1,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 2880,
+                "scenceName": "B",
+                "scenceParam": "BCYwAAADAAH//wCAFBQD/gEFiwD//38AAAAA/38AiwD/FQD+AACAACYyAAADAAH//wCAFBQD/gEFiwD//38AAAAA/38AiwD/FwD+AACAACY1AAADAAH//wCAFBQD/gEFiwD//38AAAAA/38AiwD/FQD+AACAACY3AAADAAH//wCAFBQD/gEFiwD//38AAAAA/38AiwD/FwD+AACAAA==",
+                "sceneCode": 2497,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11265,
+                    "scenceParam": "BCYwAAADAAH//wCAFBQD/gEFiwD//38AAAAA/38AiwD/FQD+AACAACYyAAADAAH//wCAFBQD/gEFiwD//38AAAAA/38AiwD/FwD+AACAACY1AAADAAH//wCAFBQD/gEFiwD//38AAAAA/38AiwD/FQD+AACAACY3AAADAAH//wCAFBQD/gEFiwD//38AAAAA/38AiwD/FwD+AACAAA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"color\":[252,254,254],\"moveIn\":[244,252,254],\"page\":0,\"defaultIndex\":2},{\"color\":[252,254,254],\"defaultIndex\":2,\"page\":1,\"moveIn\":[244,252,254]},{\"moveIn\":[244,252,254],\"color\":[252,254,254],\"defaultIndex\":2,\"page\":2},{\"page\":3,\"defaultIndex\":2,\"color\":[252,254,254],\"moveIn\":[244,252,254]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31265,
+                    "scenceParam": "BCYwAAADAAH//wCAFBQD/gEFiwD//38AAAAA/38AiwD/FQD+AACAACYyAAADAAH//wCAFBQD/gEFiwD//38AAAAA/38AiwD/FwD+AACAACY1AAADAAH//wCAFBQD/gEFiwD//38AAAAA/38AiwD/FQD+AACAACY3AAADAAH//wCAFBQD/gEFiwD//38AAAAA/38AiwD/FwD+AACAAA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"color\": [255, 255, 255], \"moveIn\": [244, 252, 254], \"page\": 0, \"defaultIndex\": 3}, {\"color\": [255, 255, 255], \"defaultIndex\": 3, \"page\": 1, \"moveIn\": [244, 252, 254]}, {\"moveIn\": [244, 252, 254], \"color\": [255, 255, 255], \"defaultIndex\": 3, \"page\": 2}, {\"page\": 3, \"defaultIndex\": 3, \"color\": [255, 255, 255], \"moveIn\": [244, 252, 254]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 152,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/dec00f4c75f2ced0420e2ddcef9f853e-new_light_btn_scenes_valentines%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/1f2315b496393e7b9158e336eb44f20e-new_light_btn_scenes_valentines_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/6cfdcddb4d3a75310cdbfb231fe55478-new_light_btn_scenes_valentines_dark%403x.png"
+            ],
+            "sceneName": "Valentine's Day",
+            "analyticName": "Valentine's Day",
+            "sceneType": 2,
+            "sceneCode": 211,
+            "scenceCategoryId": 6,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 134,
+                "scenceName": "",
+                "scenceParam": "AiMAAAABAgH/GQHIMhQC+jIE/yz/2AD/9QD//yAAEADcAAAAACMAAhkKAAH/GQD6MhQC+hQE8QAdowD//07//6X/AAAAAAD/AA==",
+                "sceneCode": 211,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 153,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/c74f3a816332829a17c3bd97db76b0ae-new_light_btn_scenes_candle%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/c18ed5192dbf86cb67aa83dd165cadb1-new_light_btn_scenes_candle_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/a4c971916efa5f440150b296ffa9056e-new_light_btn_scenes_candle_dark%403x.png"
+            ],
+            "sceneName": "Candlelight",
+            "analyticName": "Candlelight",
+            "sceneType": 0,
+            "sceneCode": 9,
+            "scenceCategoryId": 6,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 135,
+                "scenceName": "",
+                "scenceParam": "",
+                "sceneCode": 9,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 0,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 154,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/8d59b8f1eada4e1f53f117899bb9125e-new_light_btn_scenes_birthday%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/61ea786e489bb29a4056ee0eb3637cfe-new_light_btn_scenes_birthday_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/5401ad7197d70348c820b62b616709c5-new_light_btn_scenes_birthday_dark%403x.png"
+            ],
+            "sceneName": "Birthday",
+            "analyticName": "Birthday",
+            "sceneType": 2,
+            "sceneCode": 209,
+            "scenceCategoryId": 6,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 136,
+                "scenceName": "",
+                "scenceParam": "Ai8AAgoFAgL/GQAAAAD/GQAAAAAC+jIG/zgA/38AAP8AAAAAAP//iwD/AACAAAAAACMAAh4KAAH//wAAAAAB+gAE8QAd/3UA/8AA/0sAAAD/AAH6AA==",
+                "sceneCode": 209,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 155,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/9910d0a91adc1a755d999baa70b39502-new_light_btn_scenes_fireworks%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/e09ce9e9f996911d497fdbe2df6d6608-new_light_btn_scenes_fireworks_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/0c44ced83dff4b6991c9709a35d558b7-new_light_btn_scenes_fireworks_dark%403x.png"
+            ],
+            "sceneName": "Fireworks",
+            "analyticName": "Fireworks",
+            "sceneType": 2,
+            "sceneCode": 208,
+            "scenceCategoryId": 6,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 137,
+                "scenceName": "A",
+                "scenceParam": "BCNQAQAZAAH/AAD/MjICZAAE/wAAAAD/AP//////FAD/AAAAACNVAQAZAAH/AAD/MjICZAAE/wAAAAD/AP//////FgD/AAAAACkAAg8FAAH/AAL/MjIC/wIG/wAAAAAA//8AAAAAAAD/AP//AAAAEgH6ACkAAg8FAAH/AAL/MjIC/wIGiwD/AAAA//8AAAAA/3L/AP//AAAAEgH6AA==",
+                "sceneCode": 208,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11266,
+                    "scenceParam": "BCNQAQAZAAH/AAD/MjICZAAE/wAAAAD/AP//////FAD/AAAAACNVAQAZAAH/AAD/MjICZAAE/wAAAAD/AP//////FgD/AAAAACkAAg8FAAH/AAL/MjIC/wIG/wAAAAAA//8AAAAAAAD/AP//AAAAEgH6ACkAAg8FAAH/AAL/MjIC/wIGiwD/AAAA//8AAAAA/3L/AP//AAAAEgH6AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\":0,\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[244,244,252]}],\"moveIn\":[249,252,252],\"defaultIndex\":1},{\"page\":1,\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[244,244,252]}],\"defaultIndex\":1,\"moveIn\":[249,252,252]},{\"color\":[244,252,252],\"page\":2,\"moveAll\":[244,247,252],\"bright\":[{\"brightValue\":[244,249,252],\"brightPage\":\"0\"}],\"defaultIndex\":1},{\"color\":[244,252,252],\"defaultIndex\":1,\"moveAll\":[244,247,252],\"page\":3,\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[244,249,252]}]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31266,
+                    "scenceParam": "BCNQAQAZAAH/AAD/MjICZAAE/wAAAAD/AP//////FAD/AAAAACNVAQAZAAH/AAD/MjICZAAE/wAAAAD/AP//////FgD/AAAAACkAAg8FAAH/AAL/MjIC/wIG/wAAAAAA//8AAAAAAAD/AP//AAAAEgH6ACkAAg8FAAH/AAL/MjIC/wIGiwD/AAAA//8AAAAA/3L/AP//AAAAEgH6AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\": 0, \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [244, 254, 252]}], \"moveIn\": [249, 252, 252], \"defaultIndex\": 2}, {\"page\": 1, \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [244, 254, 252]}], \"defaultIndex\": 2, \"moveIn\": [249, 252, 252]}, {\"color\": [249, 255, 255], \"page\": 2, \"moveAll\": [244, 247, 252], \"bright\": [{\"brightValue\": [244, 249, 252], \"brightPage\": \"0\"}], \"defaultIndex\": 2}, {\"color\": [249, 255, 255], \"defaultIndex\": 2, \"moveAll\": [244, 247, 252], \"page\": 3, \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [244, 249, 252]}]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 235,
+                "scenceName": "B",
+                "scenceParam": "AiagAQAMAAH/AAD/PHgCZAAF/wAAiwD/AAD/AP//////FAD/AAAAADIAAh4UAAH/AAL/eDwC/gAJ/wAAAAAA//8AAAAAAAD/AAAAAP//AAAAiwD/AAAAEgP6AA==",
+                "sceneCode": 2028,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11267,
+                    "scenceParam": "AiagAQAMAAH/AAD/PHgCZAAF/wAAiwD/AAD/AP//////FAD/AAAAADIAAh4UAAH/AAL/eDwC/gAJ/wAAAAAA//8AAAAAAAD/AAAAAP//AAAAiwD/AAAAEgP6AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\":0,\"defaultIndex\":1,\"moveIn\":[252,255,255],\"color\":[100,100,252]},{\"page\":1,\"defaultIndex\":1,\"moveAll\":[244,249,252]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31267,
+                    "scenceParam": "AiagAQAMAAH/AAD/PHgCZAAF/wAAiwD/AAD/AP//////FAD/AAAAADIAAh4UAAH/AAL/eDwC/gAJ/wAAAAAA//8AAAAAAAD/AAAAAP//AAAAiwD/AAAAEgP6AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\": 0, \"defaultIndex\": 2, \"moveIn\": [252, 255, 255], \"color\": [105, 105, 255]}, {\"page\": 1, \"defaultIndex\": 2, \"moveAll\": [244, 249, 252]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 158,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/94ef14bb09f14a916e8648d5b023b16c-new_light_btn_scenes_ghost%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/aabfc8891708af6c1e858480724f3a31-new_light_btn_scenes_ghost_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/5dffd87048df3bd6758b0a1bdf471100-new_light_btn_scenes_ghost_dark%403x.png"
+            ],
+            "sceneName": "Ghost",
+            "analyticName": "Ghost",
+            "sceneType": 2,
+            "sceneCode": 220,
+            "scenceCategoryId": 6,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 140,
+                "scenceName": "A",
+                "scenceParam": "BCNQAQAKAgH/CgIAAAACAAAEiwD//3T/AP//////FAH8AAAAACNVAQAKAgH/CgIAAAACAAAEiwD/3AD/AP//////FgH8AAAAACMAAQAKAgH/CgIAAAACAAAEiwD//x3/AP//////FAH8AAAAACMFAQAKAgH/CgIAAAACAAAEiwD/4AD//1L/////FgH8AAAAAA==",
+                "sceneCode": 220,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11268,
+                    "scenceParam": "BCNQAQAKAgH/CgIAAAACAAAEiwD//3T/AP//////FAH8AAAAACNVAQAKAgH/CgIAAAACAAAEiwD/3AD/AP//////FgH8AAAAACMAAQAKAgH/CgIAAAACAAAEiwD//x3/AP//////FAH8AAAAACMFAQAKAgH/CgIAAAACAAAEiwD/4AD//1L/////FgH8AAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\":[242,249,252],\"page\":0,\"defaultIndex\":2},{\"page\":1,\"moveIn\":[242,249,252],\"defaultIndex\":2},{\"page\":2,\"defaultIndex\":2,\"moveIn\":[242,249,252]},{\"page\":3,\"defaultIndex\":2,\"moveIn\":[242,249,252]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31268,
+                    "scenceParam": "BCNQAQAKAgH/CgIAAAACAAAEiwD//3T/AP//////FAH8AAAAACNVAQAKAgH/CgIAAAACAAAEiwD/3AD/AP//////FgH8AAAAACMAAQAKAgH/CgIAAAACAAAEiwD//x3/AP//////FAH8AAAAACMFAQAKAgH/CgIAAAACAAAEiwD/4AD//1L/////FgH8AAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\": [242, 249, 252], \"page\": 0, \"defaultIndex\": 3}, {\"page\": 1, \"moveIn\": [242, 249, 252], \"defaultIndex\": 3}, {\"page\": 2, \"defaultIndex\": 3, \"moveIn\": [242, 249, 252]}, {\"page\": 3, \"defaultIndex\": 3, \"moveIn\": [242, 249, 252]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 2877,
+                "scenceName": "B",
+                "scenceParam": "ASMAAwUBAAH/AACAFBQDgBQEAAD/AAAAAAAA////EAD9EAD4AA==",
+                "sceneCode": 2494,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11269,
+                    "scenceParam": "ASMAAwUBAAH/AACAFBQDgBQEAAD/AAAAAAAA////EAD9EAD4AA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveAll\":[237,248,248],\"page\":0,\"defaultIndex\":2,\"moveIn\":[242,249,253]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31269,
+                    "scenceParam": "ASMAAwUBAAH/AACAFBQDgBQEAAD/AAAAAAAA////EAD9EAD4AA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveAll\":[237,248,248],\"page\":0,\"defaultIndex\":2,\"moveIn\":[242,249,253]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 159,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/ae241784195072ec7ba9a293bfaeb39f-new_light_btn_scenes_party%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/fa36d11000d0913769d14990163ee75d-new_light_btn_scenes_party_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/2fdd3bf5c38d5d3c10f9748b4b22f26c-new_light_btn_scenes_party_dark%403x.png"
+            ],
+            "sceneName": "Party",
+            "analyticName": "Party",
+            "sceneType": 2,
+            "sceneCode": 226,
+            "scenceCategoryId": 6,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 141,
+                "scenceName": "A",
+                "scenceParam": "AzgAAh4KAgH/GQEUAAAC/xQL/wAAAP//AAD/////AAD//wAAiwD/AAAA////AP8AiwD/AAD/AAAAACwAAh4PAgH/GQMAMjIC+gAH/wAAAP//AAD/////AAD//wAAiwD/FADIAAAAACAAAAABAAEyMgAAMjIC/woD/xP//38AAAD/EQCAAAAAAA==",
+                "sceneCode": 226,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 237,
+                "scenceName": "B",
+                "scenceParam": "BCkAAQAyAgH/AAP/CgoBpQUG/wAA/38A//8AAP8AAP//iwD/FAD/AAiAACkAAQAyAgH/sgP/CgoBowUG/wAA/38A//8AAP8AAP//iwD/FgD/EAGAASkAAQAyAAGUlACAFBQA5xQG/wAA/38A//8AAP8AAP//iwD/AACAAACAACkAAhkBAAH//wCAFBQA/xQG/wAA/38A//8AAP8AAP//iwD/AACAAACAAA==",
+                "sceneCode": 2029,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11270,
+                    "scenceParam": "BCkAAQAyAgH/AAP/CgoBpQUG/wAA/38A//8AAP8AAP//iwD/FAD/AAiAACkAAQAyAgH/sgP/CgoBowUG/wAA/38A//8AAP8AAP//iwD/FgD/EAGAASkAAQAyAAGUlACAFBQA5xQG/wAA/38A//8AAP8AAP//iwD/AACAAACAACkAAhkBAAH//wCAFBQA/xQG/wAA/38A//8AAP8AAP//iwD/AACAAACAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\":[242,249,252],\"defaultIndex\":1,\"color\":[163,163,249],\"bright\":[{\"brightValue\":[252,255,255],\"brightPage\":\"0\"}],\"page\":0},{\"moveIn\":[242,249,252],\"page\":1,\"color\":[163,163,242],\"defaultIndex\":1,\"bright\":[{\"brightValue\":[252,255,255],\"brightPage\":\"0\"}]},{\"defaultIndex\":1,\"color\":[231,231,252],\"page\":2},{\"defaultIndex\":1,\"color\":[252,252,255],\"page\":3}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31270,
+                    "scenceParam": "BCkAAQAyAgH/AAP/CgoBpQUG/wAA/38A//8AAP8AAP//iwD/FAD/AAiAACkAAQAyAgH/sgP/CgoBowUG/wAA/38A//8AAP8AAP//iwD/FgD/EAGAASkAAQAyAAGUlACAFBQA5xQG/wAA/38A//8AAP8AAP//iwD/AACAAACAACkAAhkBAAH//wCAFBQA/xQG/wAA/38A//8AAP8AAP//iwD/AACAAACAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\": [242, 249, 252], \"defaultIndex\": 2, \"color\": [168, 168, 254], \"bright\": [{\"brightValue\": [252, 255, 255], \"brightPage\": \"0\"}], \"page\": 0}, {\"moveIn\": [242, 249, 252], \"page\": 1, \"color\": [168, 168, 247], \"defaultIndex\": 2, \"bright\": [{\"brightValue\": [252, 255, 255], \"brightPage\": \"0\"}]}, {\"defaultIndex\": 2, \"color\": [236, 236, 255], \"page\": 2}, {\"defaultIndex\": 2, \"color\": [255, 255, 255], \"page\": 3}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 1773,
+                "scenceName": "C",
+                "scenceParam": "BCAAAhgBAAH//wCAFBQAgBQD/wAA/wAA/wAAEQD9AACAAiAAAhgBAAH//wCAFBQAgBQDAP8AAP8AAP8AEwD9AACAAxoAAwoKAAH//wCAFBQAgBQB/wAAAACAAACAARoAAAABAAH//wCAFBQAgBQBAP8AAACAAACAAA==",
+                "sceneCode": 2291,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11271,
+                    "scenceParam": "BCAAAhgBAAH//wCAFBQAgBQD/wAA/wAA/wAAEQD9AACAAiAAAhgBAAH//wCAFBQAgBQDAP8AAP8AAP8AEwD9AACAAxoAAwoKAAH//wCAFBQAgBQB/wAAAACAAACAARoAAAABAAH//wCAFBQAgBQBAP8AAACAAACAAA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\":0,\"moveIn\":[239,247,252],\"defaultIndex\":1},{\"page\":1,\"moveIn\":[239,247,252],\"defaultIndex\":1}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31271,
+                    "scenceParam": "BCAAAhgBAAH//wCAFBQAgBQD/wAA/wAA/wAAEQD9AACAAiAAAhgBAAH//wCAFBQAgBQDAP8AAP8AAP8AEwD9AACAAxoAAwoKAAH//wCAFBQAgBQB/wAAAACAAACAARoAAAABAAH//wCAFBQAgBQBAP8AAACAAACAAA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\": 0, \"moveIn\": [239, 247, 252], \"defaultIndex\": 2}, {\"page\": 1, \"moveIn\": [239, 247, 252], \"defaultIndex\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 160,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/db703dd42f0ea337936ebd04a6251eac-new_light_btn_scenes_prom%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/5c8b4e697adbd0a3b65f6f70f1457cae-new_light_btn_scenes_prom_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/e23a18a8bf7f3a83406a03324bd70099-new_light_btn_scenes_prom_dark%403x.png"
+            ],
+            "sceneName": "Dance Party",
+            "analyticName": "Dance Party",
+            "sceneType": 2,
+            "sceneCode": 225,
+            "scenceCategoryId": 6,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 142,
+                "scenceName": "A",
+                "scenceParam": "AiwAAh4PAgH/GQEUAAAC+gAH/wAAAP//AAD/////AAD//wAAiwD/AAD/AAAAACwAAh4PAgH/GQMAMjIC+gAH/wAAAP//AAD/////AAD//wAAiwD/AAAAAAAAAA==",
+                "sceneCode": 225,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 802,
+                "scenceName": "B",
+                "scenceParam": "AiZQAQANAAH//wD/FBQB/wEFAP//iwD//////wAA//8AFQD9AACAACZVAQANAAH//wD/FBQB/wEF//8A/wAA////iwD/AP//FwD9AACAAA==",
+                "sceneCode": 2213,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11272,
+                    "scenceParam": "AiZQAQANAAH//wD/FBQB/wEFAP//iwD//////wAA//8AFQD9AACAACZVAQANAAH//wD/FBQB/wEF//8A/wAA////iwD/AP//FwD9AACAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":2,\"color\":[239,244,249],\"moveIn\":[244,249,253],\"page\":0},{\"defaultIndex\":2,\"color\":[239,244,249],\"moveIn\":[244,249,253],\"page\":1}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31272,
+                    "scenceParam": "AiZQAQANAAH//wD/FBQB/wEFAP//iwD//////wAA//8AFQD9AACAACZVAQANAAH//wD/FBQB/wEF//8A/wAA////iwD/AP//FwD9AACAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\": 3, \"color\": [244, 249, 254], \"moveIn\": [244, 249, 253], \"page\": 0}, {\"defaultIndex\": 3, \"color\": [244, 249, 254], \"moveIn\": [244, 249, 253], \"page\": 1}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 161,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/ec9bebb7e369ca2e16fdeeb4841b8a7b-new_light_btn_scenes_disco%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/153106501b075001438b09c7650d6bef-new_light_btn_scenes_disco_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/7893ce1b8f282ee96d906632519a96b0-new_light_btn_scenes_disco_dark%403x.png"
+            ],
+            "sceneName": "Disco",
+            "analyticName": "Disco",
+            "sceneType": 2,
+            "sceneCode": 206,
+            "scenceCategoryId": 6,
+            "popUpPrompt": 2,
+            "scenesHint": "Those with epilepsy may experience discomfort when using this Scene mode. Exercise caution during use.",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 143,
+                "scenceName": "A",
+                "scenceParam": "AiwAAhQKAgH//wAAAAAB/wAH/wAAAP//AAD/////AAD//wAAiwD/AAD/EAH+ACkAAg8FAgH/CgAZAAAC/zIGiwD/AAD/AAAA////AAAA/wAAAwCAEgH+AA==",
+                "sceneCode": 206,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11273,
+                    "scenceParam": "AiwAAhQKAgH//wAAAAAB/wAH/wAAAP//AAD/////AAD//wAAiwD/AAD/EAH+ACkAAg8FAgH/CgAZAAAC/zIGiwD/AAD/AAAA////AAAA/wAAAwCAEgH+AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":1,\"moveAll\":[242,249,252],\"page\":0,\"color\":[239,247,252]},{\"defaultIndex\":1,\"page\":1,\"color\":[237,244,252],\"moveAll\":[242,249,252]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31273,
+                    "scenceParam": "AiwAAhQKAgH//wAAAAAB/wAH/wAAAP//AAD/////AAD//wAAiwD/AAD/EAH+ACkAAg8FAgH/CgAZAAAC/zIGiwD/AAD/AAAA////AAAA/wAAAwCAEgH+AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\": 2, \"moveAll\": [242, 249, 252], \"page\": 0, \"color\": [244, 252, 255]}, {\"defaultIndex\": 2, \"page\": 1, \"color\": [242, 249, 255], \"moveAll\": [242, 249, 252]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 805,
+                "scenceName": "B",
+                "scenceParam": "BSMgAQABAgH//wD/FBQB/wYE/wAAAP////8AAP8AFAD/AACAACMkAQABAgH//wD/FBQB/wYE/wAAAP8A//8AAP//FgD/AACAACMiAQABAgH//wD/FBQB/wYE/wAAAP8A//8AAP//FAD/AACAACMmAQABAgH//wD/FBQB/wYE/wAAAP8A//8AAP//FgD/AACAACMoAQABAgH//wD/FBQB/wYE/wAAAP8A//8AAP//EAD/AACAAA==",
+                "sceneCode": 2216,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11274,
+                    "scenceParam": "BSMgAQABAgH//wD/FBQB/wYE/wAAAP////8AAP8AFAD/AACAACMkAQABAgH//wD/FBQB/wYE/wAAAP8A//8AAP//FgD/AACAACMiAQABAgH//wD/FBQB/wYE/wAAAP8A//8AAP//FAD/AACAACMmAQABAgH//wD/FBQB/wYE/wAAAP8A//8AAP//FgD/AACAACMoAQABAgH//wD/FBQB/wYE/wAAAP8A//8AAP//EAD/AACAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\":[242,249,252],\"defaultIndex\":2,\"page\":0},{\"page\":1,\"moveIn\":[242,249,252],\"defaultIndex\":2},{\"defaultIndex\":2,\"moveIn\":[242,249,252],\"page\":2},{\"defaultIndex\":2,\"moveIn\":[242,249,252],\"page\":3},{\"defaultIndex\":2,\"page\":4,\"moveIn\":[242,249,252]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31274,
+                    "scenceParam": "BSMgAQABAgH//wD/FBQB/wYE/wAAAP////8AAP8AFAD/AACAACMkAQABAgH//wD/FBQB/wYE/wAAAP8A//8AAP//FgD/AACAACMiAQABAgH//wD/FBQB/wYE/wAAAP8A//8AAP//FAD/AACAACMmAQABAgH//wD/FBQB/wYE/wAAAP8A//8AAP//FgD/AACAACMoAQABAgH//wD/FBQB/wYE/wAAAP8A//8AAP//EAD/AACAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\": [242, 249, 252], \"defaultIndex\": 3, \"page\": 0}, {\"page\": 1, \"moveIn\": [242, 249, 252], \"defaultIndex\": 3}, {\"defaultIndex\": 3, \"moveIn\": [242, 249, 252], \"page\": 2}, {\"defaultIndex\": 3, \"moveIn\": [242, 249, 252], \"page\": 3}, {\"defaultIndex\": 3, \"page\": 4, \"moveIn\": [242, 249, 252]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 162,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/scence-img/8ba854821352e6b1a260c132d923bda5-new_light_btn_scenes_carnival%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/scence-img/cffe683801570c4fd98fc325b7d21add-new_light_btn_scenes_carnival_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/scence-img/74d4abaac9644e41416bc331847293c8-new_light_btn_scenes_carnival_dark%403x.png"
+            ],
+            "sceneName": "Carnival",
+            "analyticName": "Carnival",
+            "sceneType": 2,
+            "sceneCode": 230,
+            "scenceCategoryId": 6,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 144,
+                "scenceName": "",
+                "scenceParam": "BRogAQAFAgH/KAHwAAACADIB/wAAEQD8EQH8ABoiAQAFAgH/KAHwAAACADIB/38AEQD8EQH8ABokAQAFAgH/KAHwAAACADIB//8AEQD8EQH8ABomAQAFAgH/KAHwAAACADIBf/8AEAD8EQH8ABooAQAFAgH/KAHwAAACADIBAP8AEQD8EQH8AA==",
+                "sceneCode": 230,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11275,
+                    "scenceParam": "BRogAQAEAgH/KAHwAAACADIB/wAAEQDlAQD8ABoiAQAEAgH/KAHwAAACADIB/38AEQDlAQD8ABokAQAEAgH/KAHwAAACADIB//8AEQDlAQD8ABomAQAEAgH/KAHwAAACADIBf/8AEQDlAQD8ABooAQAEAgH/KAHwAAACADIBAP8AEQDlAQD8AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":2,\"moveIn\":[229,239,247,252],\"page\":0},{\"moveIn\":[229,239,247,252],\"defaultIndex\":2,\"page\":1},{\"moveIn\":[229,239,247,252],\"page\":2,\"defaultIndex\":2},{\"page\":3,\"moveIn\":[229,239,247,252],\"defaultIndex\":2},{\"defaultIndex\":2,\"page\":4,\"moveIn\":[229,239,247,252]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31275,
+                    "scenceParam": "BRogAQAEAgH/KAHwAAACADIB/wAAEQDlAQD8ABoiAQAEAgH/KAHwAAACADIB/38AEQDlAQD8ABokAQAEAgH/KAHwAAACADIB//8AEQDlAQD8ABomAQAEAgH/KAHwAAACADIBf/8AEQDlAQD8ABooAQAEAgH/KAHwAAACADIBAP8AEQDlAQD8AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\": 3, \"moveIn\": [229, 239, 247, 252], \"page\": 0}, {\"moveIn\": [229, 239, 247, 252], \"defaultIndex\": 3, \"page\": 1}, {\"moveIn\": [229, 239, 247, 252], \"page\": 2, \"defaultIndex\": 3}, {\"page\": 3, \"moveIn\": [229, 239, 247, 252], \"defaultIndex\": 3}, {\"defaultIndex\": 3, \"page\": 4, \"moveIn\": [229, 239, 247, 252]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 163,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/0557d3fd1d500b1551a2c94ed8d33eae-new_light_btn_scenes_mothers%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/fffa33f839df5234ed8145bc6fe616ef-new_light_btn_scenes_mothers_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/568cdd1499627d0249ffda418a1cbc23-new_light_btn_scenes_mothers_dark%403x.png"
+            ],
+            "sceneName": "Mother's Day",
+            "analyticName": "Mother's Day",
+            "sceneType": 2,
+            "sceneCode": 231,
+            "scenceCategoryId": 6,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 145,
+                "scenceName": "",
+                "scenceParam": "AiAAAAABAAH//wEAAAAA3DID/wsA6QD/zAD/AAAAAAAAACAAAigBAgH/KAHXIBQAADID/3///z8A////AAAAAAAAAA==",
+                "sceneCode": 231,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 164,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/1dfad4c0d6dce89445fda0a7ec0aa911-new_light_btn_scenes_fathers%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/24111abfe34bd6f6c8488390ea64e42f-new_light_btn_scenes_fathers_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/af511cacbfb63386c565cc773d376f12-new_light_btn_scenes_fathers_dark%403x.png"
+            ],
+            "sceneName": "Father's Day",
+            "analyticName": "Father's Day",
+            "sceneType": 2,
+            "sceneCode": 232,
+            "scenceCategoryId": 6,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 146,
+                "scenceName": "",
+                "scenceParam": "Ah0AAAABAAH//wEAAAAA3DICAAD/AP//AAAAAAAAABoAAigBAgH/KAHXIBQAADIB////AAAAAAAAAA==",
+                "sceneCode": 232,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 5068,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/a27a752b554b80f3ec5bab376f6ae61c-new_light_btn_scenes_shegndanshu.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/c7c7226a1b9d2e43d9ca2378015d94cc-new_light_btn_scenes_shegndanshu_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/3d066514c0e20e2219b9000c4243a53c-new_light_btn_scenes_shegndanshu_dark.png"
+            ],
+            "sceneName": "Christmas Tree",
+            "analyticName": "Christmas Tree",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 5618,
+                "scenceName": "",
+                "scenceParam": "AyYAAAAEAgGZSwOAFBQDABQFAMgeAP8A//8AAP8AAMgeAACAAACAACMAAgUDAgH/ZQPRFBQB6hQE/z9CB4H//38A/wAAAACAAACAASMAAgYDAgH/ZQPRFBQB6hQE/wAA/10H////iwD/AACAAACAAQ==",
+                "sceneCode": 5010,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11276,
+                    "scenceParam": "AyYAAAAEAgGZSwOAFBQDABQFAMgeAP8A//8AAP8AAMgeAACAAACAACMAAgUDAgH/ZQPRFBQB6hQE/z9CB4H//38A/wAAAACAAACAASMAAgYDAgH/ZQPRFBQB6hQE/wAA/10H////iwD/AACAAACAAQ==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\":1,\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[204,209,221]}],\"defaultIndex\":1,\"color\":[234,234,249]},{\"defaultIndex\":1,\"bright\":[{\"brightValue\":[204,209,221],\"brightPage\":\"0\"}],\"page\":2,\"color\":[234,234,249]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31276,
+                    "scenceParam": "AyYAAAAEAgGZSwOAFBQDABQFAMgeAP8A//8AAP8AAMgeAACAAACAACMAAgUDAgH/ZQPRFBQB6hQE/z9CB4H//38A/wAAAACAAACAASMAAgYDAgH/ZQPRFBQB6hQE/wAA/10H////iwD/AACAAACAAQ==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\": 1, \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [204, 219, 221]}], \"defaultIndex\": 2, \"color\": [239, 239, 254]}, {\"defaultIndex\": 2, \"bright\": [{\"brightValue\": [204, 219, 221], \"brightPage\": \"0\"}], \"page\": 2, \"color\": [239, 239, 254]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 5069,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/29ff982bf4647ce8d33a688cfa38f016-new_light_btn_scenes_huaxueqiao.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/9a596f048dddb88348501cddb59b18c5-new_light_btn_scenes_huaxueqiao_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/8fad389377eb9082819af34331c917a5-new_light_btn_scenes_huaxueqiao_dark.png"
+            ],
+            "sceneName": "Sled",
+            "analyticName": "Sled",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 5619,
+                "scenceName": "",
+                "scenceParam": "AyAAAAABAAHMzAAAFBQD8hQDlvH+Wt/+PMj+AgD8AACAACkAAQAGAgH/sgP5FBQBABQG/wAA/wAAUAoA/////6wI/38AEAD3EAD3ASkAAgwFAgHUsgP5FBQBABQGAP8AAP8A/38A//8AMv8I////EAD3EAD3AQ==",
+                "sceneCode": 5011,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11277,
+                    "scenceParam": "AyAAAAABAAHMzAAAFBQD8hQDlvH+Wt/+PMj+AgD8AACAACkAAQAGAgH/sgP5FBQBABQG/wAA/wAAUAoA/////6wI/38AEAD3EAD3ASkAAgwFAgHUsgP5FBQBABQGAP8AAP8A/38A//8AMv8I////EAD3EAD3AQ==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":1,\"moveIn\":[239,247,252],\"moveAll\":[239,247,252],\"page\":1},{\"moveAll\":[239,247,252],\"page\":2,\"moveIn\":[239,247,252],\"defaultIndex\":1}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31277,
+                    "scenceParam": "AyAAAAABAAHMzAAAFBQD8hQDlvH+Wt/+PMj+AgD8AACAACkAAQAGAgH/sgP5FBQBABQG/wAA/wAAUAoA/////6wI/38AEAD3EAD3ASkAAgwFAgHUsgP5FBQBABQGAP8AAP8A/38A//8AMv8I////EAD3EAD3AQ==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\": 2, \"moveIn\": [239, 247, 252], \"moveAll\": [239, 247, 252], \"page\": 1}, {\"moveAll\": [239, 247, 252], \"page\": 2, \"moveIn\": [239, 247, 252], \"defaultIndex\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 5070,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/890f7b49691e4307d914b671c7423294-new_light_btn_scenes_liwu.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/c1c279e7b9c677d167ef6b85938211c9-new_light_btn_scenes_liwu_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/3fa20a3e4b3ec5e674c6b4aecc3cc71f-new_light_btn_scenes_liwu_dark.png"
+            ],
+            "sceneName": "Christmas Gift",
+            "analyticName": "Christmas Gift",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 5620,
+                "scenceName": "",
+                "scenceParam": "AykAAgUDAAH/AAHbFBQBgBQG/wAA/38A//8AAP8AAP//iwD/AACAAACAACkAAgUDAAH/AAHoFBQBgBQG/wAA/38A//8AAP8AAP//iwD/AACAAACAABoAAAABAAH/AAHMFBQAgBQBB/8eAACAAACAAA==",
+                "sceneCode": 5012,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11278,
+                    "scenceParam": "AykAAgUDAAH/AAHbFBQBgBQG/wAA/38A//8AAP8AAP//iwD/AACAAACAACkAAgUDAAH/AAHoFBQBgBQG/wAA/38A//8AAP8AAP//iwD/AACAAACAABoAAAABAAH/AAHMFBQAgBQBB/8eAACAAACAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\":0,\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[219,229,234]}],\"defaultIndex\":0},{\"page\":1,\"defaultIndex\":0,\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[232,237,239]}]},{\"bright\":[{\"brightValue\":[204,214,226],\"brightPage\":\"0\"}],\"page\":2,\"defaultIndex\":0}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31278,
+                    "scenceParam": "AykAAgUDAAH/AAHbFBQBgBQG/wAA/38A//8AAP8AAP//iwD/AACAAACAACkAAgUDAAH/AAHoFBQBgBQG/wAA/38A//8AAP8AAP//iwD/AACAAACAABoAAAABAAH/AAHMFBQAgBQBB/8eAACAAACAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\": 0, \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [219, 239, 234]}], \"defaultIndex\": 1}, {\"page\": 1, \"defaultIndex\": 1, \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [232, 247, 239]}]}, {\"bright\": [{\"brightValue\": [204, 224, 226], \"brightPage\": \"0\"}], \"page\": 2, \"defaultIndex\": 1}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          }
+        ]
+      },
+      {
+        "categoryId": 7,
+        "categoryName": "Life",
+        "scenes": [
+          {
+            "sceneId": 165,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/e947e2ac6cc0c50e5d052a9a19fa0c3f-new_light_btn_scenes_sweet%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/6d60261796da1811495bef44182ae91f-new_light_btn_scenes_sweet_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/9d14465b7f44467c675fd7db2c78ceba-new_light_btn_scenes_sweet_dark%403x.png"
+            ],
+            "sceneName": "Sweet",
+            "analyticName": "Sweet",
+            "sceneType": 1,
+            "sceneCode": 107,
+            "scenceCategoryId": 7,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 147,
+                "scenceName": "",
+                "scenceParam": "gwH/tP8yAATwAB7qACu8AP/jAP8=",
+                "sceneCode": 107,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 1,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 166,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/8a41fe41b7b7b1e73f6e4097834ecb75-new_light_btn_scenes_romantic%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/ff9294eb079dd33e1ac00c07bf0dee4d-new_light_btn_scenes_romantic_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/c1a56c643f682212b5311f53c5d45628-new_light_btn_scenes_romantic_dark%403x.png"
+            ],
+            "sceneName": "Romantic",
+            "analyticName": "Romantic",
+            "sceneType": 0,
+            "sceneCode": 7,
+            "scenceCategoryId": 7,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 148,
+                "scenceName": "",
+                "scenceParam": "",
+                "sceneCode": 7,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 0,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 167,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/1460c148e88c49107a321db3c4b88c0c-new_light_btn_scenes_date%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/a5b384b07d88375849726b4bf0e56a89-new_light_btn_scenes_date_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/a3c01d7c6ee0e1b5e31fd74ba3a1cbdf-new_light_btn_scenes_date_dark%403x.png"
+            ],
+            "sceneName": "Dating",
+            "analyticName": "Dating",
+            "sceneType": 0,
+            "sceneCode": 5,
+            "scenceCategoryId": 7,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 149,
+                "scenceName": "",
+                "scenceParam": "",
+                "sceneCode": 5,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 0,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 168,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/a81c32bac07f656f1d10026b19b045d7-new_light_btn_scenes_movie%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/c3188d5c779e753dcc43985822b53f76-new_light_btn_scenes_movie_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/7343d77a47ecd293fbc933b2323d8c16-new_light_btn_scenes_movie_dark%403x.png"
+            ],
+            "sceneName": "Movie",
+            "analyticName": "Movie",
+            "sceneType": 0,
+            "sceneCode": 4,
+            "scenceCategoryId": 7,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 150,
+                "scenceName": "",
+                "scenceParam": "",
+                "sceneCode": 4,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 0,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 169,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/83afc240e923bb4d8d0d89716ccc3319-new_light_btn_scenes_sport%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/916c991aaf34e111e97e81a7801cf250-new_light_btn_scenes_sport_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/75dbe13c29545a80ca26e908833a8994-new_light_btn_scenes_sport_dark%403x.png"
+            ],
+            "sceneName": "Sports",
+            "analyticName": "Sports",
+            "sceneType": 2,
+            "sceneCode": 224,
+            "scenceCategoryId": 7,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 151,
+                "scenceName": "",
+                "scenceParam": "ASYAAAACAAH//wAAAAAC/zIF/wAAAAD/AAAAAP////8AEwH/AAAAAA==",
+                "sceneCode": 224,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11279,
+                    "scenceParam": "ASYAAAACAAH//wAAAAAC/zIF/wAAAAD/AAAAAP////8AEwH/AAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":1,\"page\":0,\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[224,224,237]}],\"color\":[244,252,255],\"moveIn\":[242,249,255]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31279,
+                    "scenceParam": "ASYAAAACAAH//wAAAAAC/zIF/wAAAAD/AAAAAP////8AEwH/AAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\": 2, \"page\": 0, \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [224, 234, 237]}], \"color\": [249, 255, 255], \"moveIn\": [242, 249, 255]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 170,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/f9300529a076733d697d32a3337b3803-new_light_btn_scenes_alarm%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/313af9b4f6adccb3df9532fdefd6fcff-new_light_btn_scenes_alarm_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/ec3543d9b6c9501c198c7387fd5cd7ee-new_light_btn_scenes_alarm_dark%403x.png"
+            ],
+            "sceneName": "Siren",
+            "analyticName": "Siren",
+            "sceneType": 2,
+            "sceneCode": 219,
+            "scenceCategoryId": 7,
+            "popUpPrompt": 2,
+            "scenesHint": "Siren:Those with epilepsy may experience discomfort when using this Scene mode. Exercise caution during use.",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 152,
+                "scenceName": "A",
+                "scenceParam": "Ah0AAAAKAAH//wAAAAAC/xQC/wAAAAD/EADIAAAAACMAAhQKAAH//wAAAAAA/woE////AP//AAD/////EQD+AAAAAA==",
+                "sceneCode": 219,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11280,
+                    "scenceParam": "Ah0AAAAKAAH//wAAAAAC/xQC/wAAAAD/EADIAAAAACMAAhQKAAH//wAAAAAA/woE////AP//AAD/////EQD+AAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":1,\"moveIn\":[200,200,255],\"color\":[247,252,247],\"page\":0},{\"color\":[247,252,247],\"page\":1,\"moveIn\":[247,252,255],\"defaultIndex\":1}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31280,
+                    "scenceParam": "Ah0AAAAKAAH//wAAAAAC/xQC/wAAAAD/EADIAAAAACMAAhQKAAH//wAAAAAA/woE////AP//AAD/////EQD+AAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\": 2, \"moveIn\": [200, 210, 255], \"color\": [252, 255, 252], \"page\": 0}, {\"color\": [252, 255, 252], \"page\": 1, \"moveIn\": [247, 252, 255], \"defaultIndex\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 239,
+                "scenceName": "B",
+                "scenceParam": "BR0QAAABAAH//wCAFBQA/xQCAAD//wAAAACAEQD/AB0ZAAABAAH//wCAFBQA/xQC/wAAAAD/AACAEwD/ABoRAQABAAH/AAD/FBQA//8B////EAH/AAD/ABoYAQABAAH/AAD/FBQA//8B////EAH/AACAABokAQABAAH/AAD/FBQA//8B////EAH/AACAAA==",
+                "sceneCode": 2031,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11281,
+                    "scenceParam": "BR0QAAABAAH//wCAFBQA/xQCAAD//wAAAACAEQD/AB0ZAAABAAH//wCAFBQA/xQC/wAAAAD/AACAEwD/ABoRAQABAAH/AAD/FBQA//8B////EAH/AAD/ABoYAQABAAH/AAD/FBQA//8B////EAH/AACAABokAQABAAH/AAD/FBQA//8B////EAH/AACAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"color\":[252,255,255],\"page\":0,\"defaultIndex\":1,\"moveAll\":[252,252,255]},{\"moveAll\":[252,252,255],\"color\":[252,255,255],\"defaultIndex\":1,\"page\":1},{\"moveIn\":[247,252,252],\"defaultIndex\":1,\"color\":[252,255,255],\"bright\":[{\"brightValue\":[252,255,255],\"brightPage\":\"0\"}],\"page\":2},{\"bright\":[{\"brightValue\":[252,255,255],\"brightPage\":\"0\"}],\"defaultIndex\":1,\"page\":3,\"moveIn\":[247,252,252]},{\"moveIn\":[247,252,252],\"page\":4,\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[252,255,255]}],\"defaultIndex\":1}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31281,
+                    "scenceParam": "BR0QAAABAAH//wCAFBQA/xQCAAD//wAAAACAEQD/AB0ZAAABAAH//wCAFBQA/xQC/wAAAAD/AACAEwD/ABoRAQABAAH/AAD/FBQA//8B////EAH/AAD/ABoYAQABAAH/AAD/FBQA//8B////EAH/AACAABokAQABAAH/AAD/FBQA//8B////EAH/AACAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"color\": [255, 255, 255], \"page\": 0, \"defaultIndex\": 2, \"moveAll\": [252, 252, 255]}, {\"moveAll\": [252, 252, 255], \"color\": [255, 255, 255], \"defaultIndex\": 2, \"page\": 1}, {\"moveIn\": [247, 252, 252], \"defaultIndex\": 2, \"color\": [255, 255, 255], \"bright\": [{\"brightValue\": [252, 255, 255], \"brightPage\": \"0\"}], \"page\": 2}, {\"bright\": [{\"brightValue\": [252, 255, 255], \"brightPage\": \"0\"}], \"defaultIndex\": 2, \"page\": 3, \"moveIn\": [247, 252, 252]}, {\"moveIn\": [247, 252, 252], \"page\": 4, \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [252, 255, 255]}], \"defaultIndex\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 171,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/scence-img/855215cf138b979b2b5e3af931c31424-new_light_btn_video_game%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/scence-img/66b1289a9554b40e5ad6f5dc3103cc1d-new_light_btn_video_game_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/scence-img/336973b5a6ef5c382b2a0df71bb650c5-new_light_btn_video_game_dark%403x.png"
+            ],
+            "sceneName": "Game",
+            "analyticName": "Game",
+            "sceneType": 2,
+            "sceneCode": 229,
+            "scenceCategoryId": 7,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 153,
+                "scenceName": "A",
+                "scenceParam": "AiYAAAAFAAH//wAAAAAC/zIFiwD/AAD//xP//38A/wAAEwH/AAAAACYAAAADAAH//wAAAAAC/zIFiwD/AAD/AAAA////AP//EwH/AAAAAA==",
+                "sceneCode": 229,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11282,
+                    "scenceParam": "AiYAAAAFAAH//wAAAAAC/zIFiwD/AAD//xP//38A/wAAEwH/AAAAACYAAAADAAH//wAAAAAC/zIFiwD/AAD/AAAA////AP//EwH/AAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\":[247,252,255],\"page\":0,\"defaultIndex\":1,\"color\":[247,252,252]},{\"moveIn\":[247,252,255],\"page\":1,\"color\":[247,252,252],\"defaultIndex\":1}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31282,
+                    "scenceParam": "AiYAAAAFAAH//wAAAAAC/zIFiwD/AAD//xP//38A/wAAEwH/AAAAACYAAAADAAH//wAAAAAC/zIFiwD/AAD/AAAA////AP//EwH/AAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\": [247, 252, 255], \"page\": 0, \"defaultIndex\": 2, \"color\": [252, 255, 255]}, {\"moveIn\": [247, 252, 255], \"page\": 1, \"color\": [252, 255, 255], \"defaultIndex\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 392,
+                "scenceName": "B",
+                "scenceParam": "AxoQAAABAAH/AAHtCnoAgBQB/wAAAACAAACAABoZAAABAAH/AAPuCkIAgBQBAAD/AACAAACAABqBAQABAAH/AACAFBQAgBQB////EQD+AACAAA==",
+                "sceneCode": 2125,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 1774,
+                "scenceName": "C",
+                "scenceParam": "BB0AAAABAAH//wCAFBQAgBQCAP9BAP8AAACAAACAAB0AAg0DAgH//wPPFBQAyhQCAAv/ALn/AACAEAbnBBoAAg0DAgH//wPPFBQAyhQB9wD/AACAEgboBB0ZAAAFAAH//wCAFBQC9RQC////o///AADtEQD8BQ==",
+                "sceneCode": 2292,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11283,
+                    "scenceParam": "BB0AAAABAAH//wCAFBQAgBQCAP9BAP8AAACAAACAAB0AAg0DAgH//wPPFBQAyhQCAAv/ALn/AACAEAbnBBoAAg0DAgH//wPPFBQAyhQB9wD/AACAEgboBB0ZAAAFAAH//wCAFBQC9RQC////o///AADtEQD8BQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\":0,\"bright\":[{\"brightValue\":[128,173,173],\"brightPage\":\"0\"}],\"defaultIndex\":0},{\"defaultIndex\":0,\"bright\":[{\"brightValue\":[207,216,216],\"brightPage\":\"0\"}],\"moveAll\":[231,244,252],\"page\":1},{\"defaultIndex\":0,\"bright\":[{\"brightValue\":[207,216,216],\"brightPage\":\"0\"}],\"page\":2,\"moveAll\":[232,244,252]},{\"defaultIndex\":0,\"color\":[245,252,252],\"page\":3,\"moveAll\":[252,255,255]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31283,
+                    "scenceParam": "BB0AAAABAAH//wCAFBQAgBQCAP9BAP8AAACAAACAAB0AAg0DAgH//wPPFBQAyhQCAAv/ALn/AACAEAbnBBoAAg0DAgH//wPPFBQAyhQB9wD/AACAEgboBB0ZAAAFAAH//wCAFBQC9RQC////o///AADtEQD8BQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\": 0, \"bright\": [{\"brightValue\": [128, 183, 173], \"brightPage\": \"0\"}], \"defaultIndex\": 1}, {\"defaultIndex\": 1, \"bright\": [{\"brightValue\": [207, 226, 216], \"brightPage\": \"0\"}], \"moveAll\": [231, 254, 252], \"page\": 1}, {\"defaultIndex\": 1, \"bright\": [{\"brightValue\": [207, 226, 216], \"brightPage\": \"0\"}], \"page\": 2, \"moveAll\": [232, 254, 252]}, {\"defaultIndex\": 1, \"color\": [250, 255, 255], \"page\": 3, \"moveAll\": [252, 255, 255]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 2875,
+                "scenceName": "D",
+                "scenceParam": "BR0QAAABAAH//wCAFBQA/xQCiwD/AP8AAACAEQD/AB0ZAAABAAH//wD/FBQA/xQCAP8AiwD/AACAEwD/ABoRAQABAAH/AAD/FBQA//8B////EAH/AAD/AhoYAQABAAH/AAD/FBQA//8B////EAH/AACAAh0kAgoBAAH//wD/FBQA/xQCiwD/AP8AEQH/AACAAw==",
+                "sceneCode": 2492,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11284,
+                    "scenceParam": "BR0QAAABAAH//wCAFBQA/xQCiwD/AP8AAACAEQD/AB0ZAAABAAH//wD/FBQA/xQCAP8AiwD/AACAEwD/ABoRAQABAAH/AAD/FBQA//8B////EAH/AAD/AhoYAQABAAH/AAD/FBQA//8B////EAH/AACAAh0kAgoBAAH//wD/FBQA/xQCiwD/AP8AEQH/AACAAw==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\":0,\"bright\":[{\"brightValue\":[128,173,173],\"brightPage\":\"0\"}],\"defaultIndex\":0},{\"defaultIndex\":0,\"bright\":[{\"brightValue\":[207,216,216],\"brightPage\":\"0\"}],\"moveAll\":[231,244,252],\"page\":1},{\"defaultIndex\":0,\"bright\":[{\"brightValue\":[207,216,216],\"brightPage\":\"0\"}],\"page\":2,\"moveAll\":[232,244,252]},{\"defaultIndex\":0,\"color\":[245,252,252],\"page\":3,\"moveAll\":[252,255,255]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31284,
+                    "scenceParam": "BR0QAAABAAH//wCAFBQA/xQCiwD/AP8AAACAEQD/AB0ZAAABAAH//wD/FBQA/xQCAP8AiwD/AACAEwD/ABoRAQABAAH/AAD/FBQA//8B////EAH/AAD/AhoYAQABAAH/AAD/FBQA//8B////EAH/AACAAh0kAgoBAAH//wD/FBQA/xQCiwD/AP8AEQH/AACAAw==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\": 0, \"bright\": [{\"brightValue\": [128, 183, 173], \"brightPage\": \"0\"}], \"defaultIndex\": 1}, {\"defaultIndex\": 1, \"bright\": [{\"brightValue\": [207, 226, 216], \"brightPage\": \"0\"}], \"moveAll\": [231, 254, 252], \"page\": 1}, {\"defaultIndex\": 1, \"bright\": [{\"brightValue\": [207, 226, 216], \"brightPage\": \"0\"}], \"page\": 2, \"moveAll\": [232, 254, 252]}, {\"defaultIndex\": 1, \"color\": [250, 255, 255], \"page\": 3, \"moveAll\": [252, 255, 255]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 172,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/99db62a3df5ee45dd039f8463c0025e6-new_light_btn_scenes_chase%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/9cf90fe3b99c2db4f59b9ae881205c76-new_light_btn_scenes_chase_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/edd2d80dd2d15daa26957dca1323e46a-new_light_btn_scenes_chase_dark%403x.png"
+            ],
+            "sceneName": "Crossing",
+            "analyticName": "Crossing",
+            "sceneType": 0,
+            "sceneCode": 21,
+            "scenceCategoryId": 7,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 154,
+                "scenceName": "",
+                "scenceParam": "",
+                "sceneCode": 21,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 0,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 173,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/623fa3b2349dab34f8e37e927b85b91b-new_light_btn_scenes_night%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/2a726c7cdae955a874906c3dd3f41a39-new_light_btn_scenes_night_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/63747196e529ec08581a68088fb375be-new_light_btn_scenes_night_dark%403x.png"
+            ],
+            "sceneName": "Night",
+            "analyticName": "Night",
+            "sceneType": 2,
+            "sceneCode": 233,
+            "scenceCategoryId": 7,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 155,
+                "scenceName": "A",
+                "scenceParam": "Ah0AAAAFAAGWBQGWMjIC3DICAAD/nADIAAAAAAAAACAAAAADAgGWBQHXMjICADIDiwD/AAAAAAD/AAAAAAAAAA==",
+                "sceneCode": 233,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 804,
+                "scenceName": "B",
+                "scenceParam": "BB0AAAAFAAH//wAAFBQDyBQCJU/+/wb9AACAAACAABoAAhAQAAEREQAvFBQAERQB////AACAAACAARoAAQABAAEREQAAFBQAgBQB////EAD9AACAARoAAQABAAEREQAAFBQAgBQB////EgD9AACAAQ==",
+                "sceneCode": 2215,
+                "specialEffect": [],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 174,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/927cf66fc71121171cc1daae6c353a92-new_light_btn_scenes_sleep%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/69f6064cc1a3e5d6cd76f01f8ec0d1d5-new_light_btn_scenes_sleep_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/50f1a44e2a99f69cab8d055c6495657b-new_light_btn_scenes_sleep_dark%403x.png"
+            ],
+            "sceneName": "Sleep",
+            "analyticName": "Sleep",
+            "sceneType": 2,
+            "sceneCode": 234,
+            "scenceCategoryId": 7,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 156,
+                "scenceName": "A",
+                "scenceParam": "ASAAAAAFAAFMMwGWMjIC3DID/38A/0EA/7AAAAAAAAAAAA==",
+                "sceneCode": 234,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 708,
+                "scenceName": "B",
+                "scenceParam": "AxoAAAABAAEiIgAAFBQAAGoBWgz+AACAAACAACMAAwIEAAH/OwHIFBQB3xQEAAD/LMD/P2P/V0L+EgCoAACAACMAAwIEAAH/OwHIFBQB3xQEAAD/LMD/P2P/V0L+EACoAACAAA==",
+                "sceneCode": 2201,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11285,
+                    "scenceParam": "AxoAAAABAAEiIgAAFBQAAGoBWgz+AACAAACAACMAAwIEAAH/OwHIFBQB3xQEAAD/LMD/P2P/V0L+EgCoAACAACMAAwIEAAH/OwHIFBQB3xQEAAD/LMD/P2P/V0L+EACoAACAAA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"bright\":[{\"brightValue\":[200,201,204],\"brightPage\":\"0\"}],\"page\":1,\"defaultIndex\":0,\"color\":[223,224,224],\"moveIn\":[155,168,168]},{\"color\":[223,224,224],\"defaultIndex\":0,\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[200,201,204]}],\"moveIn\":[155,168,168],\"page\":2}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31285,
+                    "scenceParam": "AxoAAAABAAEiIgAAFBQAAGoBWgz+AACAAACAACMAAwIEAAH/OwHIFBQB3xQEAAD/LMD/P2P/V0L+EgCoAACAACMAAwIEAAH/OwHIFBQB3xQEAAD/LMD/P2P/V0L+EACoAACAAA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"bright\": [{\"brightValue\": [200, 211, 204], \"brightPage\": \"0\"}], \"page\": 1, \"defaultIndex\": 1, \"color\": [228, 229, 229], \"moveIn\": [155, 178, 168]}, {\"color\": [228, 229, 229], \"defaultIndex\": 1, \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [200, 211, 204]}], \"moveIn\": [155, 178, 168], \"page\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 1776,
+                "scenceName": "C",
+                "scenceParam": "Ah0AAAAFAAH/YQGnFBQCuRQCAP//iwD/AACAAACAAB0wAAAJAAH//wCAFBQCgAgCAAD/AP8AAACAEQHrAQ==",
+                "sceneCode": 2294,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 175,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/5c77d823d59cab03932230743d08e65e-new_light_btn_scenes_early_morning%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/aab38322cb82956c682562db13f76d0e-new_light_btn_scenes_early_morning_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/8a8e4df26f81adb228b3ef70ad52da4e-new_light_btn_scenes_early_morning_dark%403x.png"
+            ],
+            "sceneName": "Morning",
+            "analyticName": "Morning",
+            "sceneType": 2,
+            "sceneCode": 235,
+            "scenceCategoryId": 7,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 157,
+                "scenceName": "",
+                "scenceParam": "Ah0AAAABAAHIMgFkMjIAyDIC////AP//AAAAAAAAABoAAgoBAgH/KAG0MjIAADIBAP+WAAAAAAAAAA==",
+                "sceneCode": 235,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 176,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/2db69110a985de0dc3264c7d72d2d7ae-new_light_btn_scenes_afternoon%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/a344ab13c77aacf300618034e2e64a6c-new_light_btn_scenes_afternoon_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/46101f5188869a2f376661e3bd1c1ca1-new_light_btn_scenes_afternoon_dark%403x.png"
+            ],
+            "sceneName": "Afternoon",
+            "analyticName": "Afternoon",
+            "sceneType": 2,
+            "sceneCode": 236,
+            "scenceCategoryId": 7,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 158,
+                "scenceName": "",
+                "scenceParam": "Ah0AAAABAAH//wAAAAAA3DIC////AP//AAAAAAAAAB0AAgoBAgH/KAHXAAAA+jICAMX/////AAAAAAAAAA==",
+                "sceneCode": 236,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 177,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/0d4ce20f3e09e2cdc8e57b394a22a24a-new_light_btn_scenes_learn%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/638a812507d91977109528d3bc7dd000-new_light_btn_scenes_learn_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/35724b338d69e39876ac6e4d8db0f98e-new_light_btn_scenes_learn_dark%403x.png"
+            ],
+            "sceneName": "Study",
+            "analyticName": "Study",
+            "sceneType": 2,
+            "sceneCode": 237,
+            "scenceCategoryId": 7,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 159,
+                "scenceName": "",
+                "scenceParam": "AiAAAAAKAAH//wGWMjICyDID////fP//AAAAAAAAAAAAAB0AAAAFAAH//wD/AAACljICtv//////AAAAAAAAAA==",
+                "sceneCode": 237,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 178,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/a0521466859450d728eaeb17afd15515-new_light_btn_scenes_business%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/e1a81f5337e085f839c14cb7379137c0-new_light_btn_scenes_business_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/d0162cc4bb86ae3dbff3ab9cf080bb50-new_light_btn_scenes_business_dark%403x.png"
+            ],
+            "sceneName": "Business",
+            "analyticName": "Business",
+            "sceneType": 2,
+            "sceneCode": 238,
+            "scenceCategoryId": 7,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 160,
+                "scenceName": "",
+                "scenceParam": "ASMAAAAFAAH/lgGWMjIC3DIE////YP//0P//////AAAAAAAAAA==",
+                "sceneCode": 238,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 179,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/eacff922c87ea4f0f6f4d0e07762bc6d-new_light_btn_scenes_reading%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/599fe425cd03417881c8b99b1548f53b-new_light_btn_scenes_reading_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/fe591a8a2a347ffef5d01958eeb1fef1-new_light_btn_scenes_reading_dark%403x.png"
+            ],
+            "sceneName": "Reading",
+            "analyticName": "Reading",
+            "sceneType": 2,
+            "sceneCode": 239,
+            "scenceCategoryId": 7,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 161,
+                "scenceName": "",
+                "scenceParam": "ASAAAAAFAAH//wGWMjIC3DID/38A/7AA/7oAAAAAAAAAAA==",
+                "sceneCode": 239,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 225,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/37a47315fdb8768b41996298b03d36f3-new_light_btn_scenes_work%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/bef75806198dfb950fb3a6ff91e91a51-new_light_btn_scenes_work_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/54cdb47ad7fc9162da43cd3bddf000de-new_light_btn_scenes_work_dark%403x.png"
+            ],
+            "sceneName": "Work",
+            "analyticName": "Work",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 205,
+                "scenceName": "",
+                "scenceParam": "AR0AAAABAgH//wAAAAAA+pYC////j///AAAAAAAAAA==",
+                "sceneCode": 2014,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 226,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/df5a38ceddc9d13d44ee79636a20378c-new_light_btn_scenes_rest%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/e4a0a56ffde980e090dc956389bb1655-new_light_btn_scenes_rest_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/421b1832b0a9e4d21845321b62c802d9-new_light_btn_scenes_rest_dark%403x.png"
+            ],
+            "sceneName": "Leisure",
+            "analyticName": "Leisure",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 206,
+                "scenceName": "A",
+                "scenceParam": "AiAAAAABAgH/MgAAAAAA9TID/wAA/2wA/38AAwCAAAAAAB2gAAAFAgH/MgD/FBQA8DIC/1AA7AAmAwCAEQD8AA==",
+                "sceneCode": 2015,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11286,
+                    "scenceParam": "AiAAAAABAgH/MgAAAAAA9TID/wAA/2wA/38AAwCAAAAAAB2gAAAFAgH/MgD/FBQA8DIC/1AA7AAmAwCAEQD8AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveAll\":[244,252,255],\"page\":1,\"defaultIndex\":1}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31286,
+                    "scenceParam": "AiAAAAABAgH/MgAAAAAA9TID/wAA/2wA/38AAwCAAAAAAB2gAAAFAgH/MgD/FBQA8DIC/1AA7AAmAwCAEQD8AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveAll\": [244, 252, 255], \"page\": 1, \"defaultIndex\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 2883,
+                "scenceName": "B",
+                "scenceParam": "AyMAAhkDAAH/GgOAFBQAgBQE/wAAAP8ACwv//38AEQD+AACAACMAAQAZAAHLZgNBFBQA8hQEAAD/AP8A/wAAiwD/EAD7AACAACkAAQAQAgH/AAOAFBQBzRQG////AAAAAAAA////////AAAAEQDzAACAAA==",
+                "sceneCode": 2500,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11287,
+                    "scenceParam": "AyMAAhkDAAH/GgOAFBQAgBQE/wAAAP8ACwv//38AEQD+AACAACMAAQAZAAHLZgNBFBQA8hQEAAD/AP8A/wAAiwD/EAD7AACAACkAAQAQAgH/AAOAFBQBzRQG////AAAAAAAA////////AAAAEQDzAACAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\":0,\"defaultIndex\":1,\"moveIn\":[244,254,254]},{\"page\":1,\"defaultIndex\":1,\"moveIn\":[237,251,252]},{\"moveIn\":[229,243,252],\"page\":2,\"defaultIndex\":1}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31287,
+                    "scenceParam": "AyMAAhkDAAH/GgOAFBQAgBQE/wAAAP8ACwv//38AEQD+AACAACMAAQAZAAHLZgNBFBQA8hQEAAD/AP8A/wAAiwD/EAD7AACAACkAAQAQAgH/AAOAFBQBzRQG////AAAAAAAA////////AAAAEQDzAACAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\": 0, \"defaultIndex\": 2, \"moveIn\": [244, 254, 254]}, {\"page\": 1, \"defaultIndex\": 2, \"moveIn\": [237, 251, 252]}, {\"moveIn\": [229, 253, 252], \"page\": 2, \"defaultIndex\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 227,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/5c2b268e5f547c541394668d5b4342c8-new_light_btn_scenes_meditation%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/f4dd5a45696f4696978a3108a61fcd76-new_light_btn_scenes_meditation_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/402d25f0ccd33f4d83f2d8412e74b808-new_light_btn_scenes_meditation_dark%403x.png"
+            ],
+            "sceneName": "Meditation",
+            "analyticName": "Meditation",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 207,
+                "scenceName": "A",
+                "scenceParam": "AiMAAh4eAgH/lgAAAAAA+jIEAAB4ADJ4AAD/AHv/AwCAAAAAAB0AAQAyAgH/MgAAMgAA+jICAAB4AABQAwCAAAAAAA==",
+                "sceneCode": 2016,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 714,
+                "scenceName": "B",
+                "scenceParam": "BBoAAwMDAgH/AACAFBQAgBQBAP//EgD5AACAABoAAwQEAgH/AACAFBQAgBQBiwD/EAD4AACAASkAAAAyAgH/AACAFBQA7hQGAAD/AAAAAAAAAAAAAAAAAP/CFAD9AACAAy8AAAAyAgL/AALIFBQAAACsFBQA7hQGiwD/AAAAAAAA/wDLAAAAAP+8FgD9AACABA==",
+                "sceneCode": 2207,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11288,
+                    "scenceParam": "BBoAAwMDAgH/AACAFBQAgBQBAP//EgD5AACAABoAAwQEAgH/AACAFBQAgBQBiwD/EAD4AACAASkAAAAyAgH/AACAFBQA7hQGAAD/AAAAAAAAAAAAAAAAAP/CFAD9AACAAy8AAAAyAgL/AALIFBQAAACsFBQA7hQGiwD/AAAAAAAA/wDLAAAAAP+8FgD9AACABA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\":[232,239,247],\"page\":0,\"defaultIndex\":2},{\"page\":1,\"defaultIndex\":2,\"moveIn\":[232,239,248]},{\"moveIn\":[234,242,249],\"page\":2,\"defaultIndex\":2,\"color\":[226,232,238]},{\"defaultIndex\":2,\"bright\":[{\"brightValue\":[191,200,200],\"brightPage\":\"0\"}],\"moveIn\":[234,242,249],\"color\":[226,232,238],\"page\":3}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31288,
+                    "scenceParam": "BBoAAwMDAgH/AACAFBQAgBQBAP//EgD5AACAABoAAwQEAgH/AACAFBQAgBQBiwD/EAD4AACAASkAAAAyAgH/AACAFBQA7hQGAAD/AAAAAAAAAAAAAAAAAP/CFAD9AACAAy8AAAAyAgL/AALIFBQAAACsFBQA7hQGiwD/AAAAAAAA/wDLAAAAAP+8FgD9AACABA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\": [232, 249, 247], \"page\": 0, \"defaultIndex\": 3}, {\"page\": 1, \"defaultIndex\": 3, \"moveIn\": [232, 249, 248]}, {\"moveIn\": [234, 252, 249], \"page\": 2, \"defaultIndex\": 3, \"color\": [231, 237, 243]}, {\"defaultIndex\": 2, \"bright\": [{\"brightValue\": [191, 210, 200], \"brightPage\": \"0\"}], \"moveIn\": [234, 252, 249], \"color\": [231, 237, 243], \"page\": 3}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 715,
+                "scenceName": "C",
+                "scenceParam": "AR0AAAABAAH//wCAFBQD2BQCAP9SAAAAAACAAACAAA==",
+                "sceneCode": 2208,
+                "specialEffect": [],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 228,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/cab5932590a0c076f665fb17a688dd2e-new_light_btn_scenes_care%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/7a1cef6a4943d5a2a65ff46beb103a14-new_light_btn_scenes_care_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/06f9c7ef861609b15fbbbb1056791295-new_light_btn_scenes_care_dark%403x.png"
+            ],
+            "sceneName": "Care",
+            "analyticName": "Care",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 208,
+                "scenceName": "A",
+                "scenceParam": "AxoAAQAyAAH/lgEAFBQA+gABUBIAAwCAAAAAAB1QAAAUAAH/ZADIFBQA+gAC/wAA/yEAFAD6AAD/AB1VAAAUAAH/ZADIFBQA+gAC/yMA/wAAFgD6AAD/AA==",
+                "sceneCode": 2017,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11289,
+                    "scenceParam": "AxoAAQAyAAH/lgEAFBQA+gABUBIAAwCAAAAAAB1QAAAUAAH/ZADIFBQA+gAC/wAA/yEAFAD6AAD/AB1VAAAUAAH/ZADIFBQA+gAC/yMA/wAAFgD6AAD/AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\":[242,249,252],\"page\":1,\"defaultIndex\":1},{\"defaultIndex\":1,\"page\":2,\"moveIn\":[242,249,252]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31289,
+                    "scenceParam": "AxoAAQAyAAH/lgEAFBQA+gABUBIAAwCAAAAAAB1QAAAUAAH/ZADIFBQA+gAC/wAA/yEAFAD6AAD/AB1VAAAUAAH/ZADIFBQA+gAC/yMA/wAAFgD6AAD/AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\": [242, 249, 252], \"page\": 1, \"defaultIndex\": 2}, {\"defaultIndex\": 2, \"page\": 2, \"moveIn\": [242, 249, 252]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 240,
+                "scenceName": "B",
+                "scenceParam": "BRoAAAABAAH//wAAFBQAABQB/wAAAACAAACAAB0iAQAFAAH/GAPFZFAAhhQCAAD//wAAAAGAEQD6AB0gAQAFAAH/GAPFZFAAfhQCAAD//wAAAAGAEQD7AB0mAQAFAAH/GAPFZFAAghQCAAD//wAAAAGAEQD7AB0oAQAFAAH/GAPFZFAAgBQCAAD//wAAAAGAEQD7AA==",
+                "sceneCode": 2032,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 253,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/771869b1b951c12c8ee2c39baef09872-new_light_btn_scenes_duikang.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/3964a401728018405fabd5b35456e0ac-new_light_btn_scenes_duikang_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/806df2757e45d5eb3ecb449f41c89c71-new_light_btn_scenes_duikang_dark.png"
+            ],
+            "sceneName": "Fight",
+            "analyticName": "Fight",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 252,
+                "scenceName": "",
+                "scenceParam": "BSMgAQADAgH//wD/FBQB/wYE/wAAAP////8AAP8AFAD/AACAACMkAQADAgH//wD/FBQB/wYE/wAAAP8A//8AAP//FgD/AACAACMiAQADAgH//wD/FBQB/wYE/wAAAP8A//8AAP//FAD/AACAACMmAQADAgH//wD/FBQB/wYE/wAAAP8A//8AAP//FgD/AACAACMoAQADAgH//wD/FBQB/wYE/wAAAP8A//8AAP//EAD/AACAAA==",
+                "sceneCode": 2071,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11290,
+                    "scenceParam": "BSMgAQADAgH//wD/FBQB/wYE/wAAAP////8AAP8AFAD/AACAACMkAQADAgH//wD/FBQB/wYE/wAAAP8A//8AAP//FgD/AACAACMiAQADAgH//wD/FBQB/wYE/wAAAP8A//8AAP//FAD/AACAACMmAQADAgH//wD/FBQB/wYE/wAAAP8A//8AAP//FgD/AACAACMoAQADAgH//wD/FBQB/wYE/wAAAP8A//8AAP//EAD/AACAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\":[242,249,252],\"page\":0,\"defaultIndex\":1},{\"page\":1,\"defaultIndex\":1,\"moveIn\":[242,249,252]},{\"page\":2,\"defaultIndex\":1,\"moveIn\":[242,249,252]},{\"moveIn\":[242,249,252],\"page\":3,\"defaultIndex\":1},{\"defaultIndex\":1,\"moveIn\":[242,249,252],\"page\":4}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31290,
+                    "scenceParam": "BSMgAQADAgH//wD/FBQB/wYE/wAAAP////8AAP8AFAD/AACAACMkAQADAgH//wD/FBQB/wYE/wAAAP8A//8AAP//FgD/AACAACMiAQADAgH//wD/FBQB/wYE/wAAAP8A//8AAP//FAD/AACAACMmAQADAgH//wD/FBQB/wYE/wAAAP8A//8AAP//FgD/AACAACMoAQADAgH//wD/FBQB/wYE/wAAAP8A//8AAP//EAD/AACAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\": [242, 249, 252], \"page\": 0, \"defaultIndex\": 2}, {\"page\": 1, \"defaultIndex\": 2, \"moveIn\": [242, 249, 252]}, {\"page\": 2, \"defaultIndex\": 2, \"moveIn\": [242, 249, 252]}, {\"moveIn\": [242, 249, 252], \"page\": 3, \"defaultIndex\": 2}, {\"defaultIndex\": 2, \"moveIn\": [242, 249, 252], \"page\": 4}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 7610,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/f9362b574e10a8d557469f680771d597-new_light_btn_scenes_fantasy.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/948aca8c0ac48e5267d14e7e825d5dfd-new_light_btn_scenes_fantasy_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/71dc811a5b255b1ca1b79e672f2cf06e-new_light_btn_scenes_fantasy_dark.png"
+            ],
+            "sceneName": "Dreamlike",
+            "analyticName": "Dreamlike",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 11012,
+                "scenceName": "A",
+                "scenceParam": "AiMAAAAEAgH/UACAFBQDtgoEElP+iwD/MU7/iwD/AAD6AACAACAAAggBAAH//wM9CgoA/gED////AP//Nsn+AADuAACAAA==",
+                "sceneCode": 10114,
+                "specialEffect": [],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 11835,
+                "scenceName": "B",
+                "scenceParam": "ASkAAAAKAgH/sQDqFBQD7woGHVP+bTf+/3lH/0hc/2HCWRz/AAD6AACAAA==",
+                "sceneCode": 10190,
+                "specialEffect": [],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          }
+        ]
+      },
+      {
+        "categoryId": 8,
+        "categoryName": "Emotion",
+        "scenes": [
+          {
+            "sceneId": 180,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/d0de43fe14cd7fcfcb070aae1a6dc1d5-new_light_btn_scenes_blinking%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/0c8087ed220544b34b1064a2ebd3d639-new_light_btn_scenes_blinking_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/3bd63ea466235b61efd02db634143cb7-new_light_btn_scenes_blinking_dark%403x.png"
+            ],
+            "sceneName": "Twinkle",
+            "analyticName": "Twinkle",
+            "sceneType": 0,
+            "sceneCode": 8,
+            "scenceCategoryId": 8,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 162,
+                "scenceName": "A",
+                "scenceParam": "",
+                "sceneCode": 8,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 0,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 181,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/7dcc672121ffae7f7eafa7a1bf7ae4ba-new_light_btn_scenes_dreamland%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/2e0aba09ffe4eb031c3b4b003f7f4326-new_light_btn_scenes_dreamland_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/f05f2b087f106925854cac08313c4fe0-new_light_btn_scenes_dreamland_dark%403x.png"
+            ],
+            "sceneName": "Dreamland",
+            "analyticName": "Dreamland",
+            "sceneType": 2,
+            "sceneCode": 207,
+            "scenceCategoryId": 8,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 163,
+                "scenceName": "A",
+                "scenceParam": "AxoAAAABAgH/FAHcFBQA+jIBAP//AwCAAAAAACwAAh4KAAH/GQHIFBQC+hQH/7v/zQD/////uQD/AOD/ABH/iwD/AAAAAAD/ACwAAAAKAAH/GQHIFBQC3DIH/7v/zQD/////uQD/AOD/ABH/iwD/EQD8AAD/AA==",
+                "sceneCode": 207,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11291,
+                    "scenceParam": "AxoAAAABAgH/FAHcFBQA+jIBAP//AwCAAAAAACwAAh4KAAH/GQHIFBQC+hQH/7v/zQD/////uQD/AOD/ABH/iwD/AAAAAAD/ACwAAAAKAAH/GQHIFBQC3DIH/7v/zQD/////uQD/AOD/ABH/iwD/EQD8AAD/AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":1,\"color\":[247,250,250],\"page\":1},{\"moveIn\":[244,252,255],\"page\":2,\"defaultIndex\":1}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31291,
+                    "scenceParam": "AxoAAAABAgH/FAHcFBQA+jIBAP//AwCAAAAAACwAAh4KAAH/GQHIFBQC+hQH/7v/zQD/////uQD/AOD/ABH/iwD/AAAAAAD/ACwAAAAKAAH/GQHIFBQC3DIH/7v/zQD/////uQD/AOD/ABH/iwD/EQD8AAD/AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\": 2, \"color\": [252, 255, 255], \"page\": 1}, {\"moveIn\": [244, 252, 255], \"page\": 2, \"defaultIndex\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 241,
+                "scenceName": "B",
+                "scenceParam": "BRoAAQAFAAH//wCAFBQB/xQB2gf/FQD/AACAARoAAQAFAAH//wCAFBQB/xQB/7cHFQH9AACAARoAAQAFAAH//wCAFBQB/xQB/zkHEQL6AwCAARoAAQAFAAH//wCAFBQB/xQB/wbZFQD6AACAAR0AAAAwAAH//wCAFBQAwxQC/0AH/weNBQT3AACAAA==",
+                "sceneCode": 2033,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11292,
+                    "scenceParam": "BRoAAQAFAAH//wCAFBQB/xQB2gf/FQD/AACAARoAAQAFAAH//wCAFBQB/xQB/7cHFQH9AACAARoAAQAFAAH//wCAFBQB/xQB/zkHEQL6AwCAARoAAQAFAAH//wCAFBQB/xQB/wbZFQD6AACAAR0AAAAwAAH//wCAFBQAwxQC/0AH/weNBQT3AACAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":1,\"moveIn\":[247,252,252],\"page\":0},{\"moveIn\":[247,252,252],\"defaultIndex\":1,\"page\":1},{\"defaultIndex\":1,\"page\":2,\"moveIn\":[247,252,252]},{\"page\":3,\"moveIn\":[247,252,255],\"defaultIndex\":1}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31292,
+                    "scenceParam": "BRoAAQAFAAH//wCAFBQB/xQB2gf/FQD/AACAARoAAQAFAAH//wCAFBQB/xQB/7cHFQH9AACAARoAAQAFAAH//wCAFBQB/xQB/zkHEQL6AwCAARoAAQAFAAH//wCAFBQB/xQB/wbZFQD6AACAAR0AAAAwAAH//wCAFBQAwxQC/0AH/weNBQT3AACAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\": 2, \"moveIn\": [247, 252, 252], \"page\": 0}, {\"moveIn\": [247, 252, 252], \"defaultIndex\": 2, \"page\": 1}, {\"defaultIndex\": 2, \"page\": 2, \"moveIn\": [247, 252, 252]}, {\"page\": 3, \"moveIn\": [247, 252, 255], \"defaultIndex\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 242,
+                "scenceName": "C",
+                "scenceParam": "AyYAAAABAgH//wAAAQEA0AEF/wAA/2UHAP8AAAD/iwD/AACAAACAACYAAQAMAAH//wCAFBQCAAEFiwD/AAD/AP8A/zEH/wAAFgD9AACAASYAAQAMAAH//wCAFBQCAAEFiwD/AAD/AP8A/zkH/wAAFAD9AACAAg==",
+                "sceneCode": 2075,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11293,
+                    "scenceParam": "AyYAAAABAgH//wAAAQEA0AEF/wAA/2UHAP8AAAD/iwD/AACAAACAACYAAQAMAAH//wCAFBQCAAEFiwD/AAD/AP8A/zEH/wAAFgD9AACAASYAAQAMAAH//wCAFBQCAAEFiwD/AAD/AP8A/zkH/wAAFAD9AACAAg==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\":1,\"moveIn\":[239,247,253,255],\"defaultIndex\":2},{\"moveIn\":[239,247,253,255],\"defaultIndex\":2,\"page\":2}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31293,
+                    "scenceParam": "AyYAAAABAgH//wAAAQEA0AEF/wAA/2UHAP8AAAD/iwD/AACAAACAACYAAQAMAAH//wCAFBQCAAEFiwD/AAD/AP8A/zEH/wAAFgD9AACAASYAAQAMAAH//wCAFBQCAAEFiwD/AAD/AP8A/zkH/wAAFAD9AACAAg==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\": 1, \"moveIn\": [239, 247, 253, 255], \"defaultIndex\": 3}, {\"moveIn\": [239, 247, 253, 255], \"defaultIndex\": 3, \"page\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 243,
+                "scenceName": "D",
+                "scenceParam": "Ah0AAhkBAAG7NgF9FBQC6zsCAP8A//8AFQzJExrYASAAAAABAgGmRACAFBQBRQEDAAD/iwD/AP//ACCYAADdAA==",
+                "sceneCode": 2034,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11294,
+                    "scenceParam": "Ah0AAhkBAAG7NgF9FBQC6zsCAP8A//8AFQzJExrYASAAAAABAgGmRACAFBQBRQEDAAD/iwD/AP//ACCYAADdAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"bright\":[{\"brightValue\":[125,125,145],\"brightPage\":\"0\"}],\"moveAll\":[198,216,229],\"moveIn\":[183,201,224],\"defaultIndex\":1,\"page\":0}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31294,
+                    "scenceParam": "Ah0AAhkBAAG7NgF9FBQC6zsCAP8A//8AFQzJExrYASAAAAABAgGmRACAFBQBRQEDAAD/iwD/AP//ACCYAADdAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"bright\": [{\"brightValue\": [125, 135, 145], \"brightPage\": \"0\"}], \"moveAll\": [198, 226, 229], \"moveIn\": [183, 211, 224], \"defaultIndex\": 2, \"page\": 0}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 710,
+                "scenceName": "E",
+                "scenceParam": "BClQAAABAAGMjAAAFBQB9xQG/wfP3gb+lgf+Twf/CAb/Bxf/EgCWAACAAClVAAABAAGMjAAAFBQB9xQG/wfP3gb+lgf+Twf/CAb/Bxf/EACWAACAAB0AAwEIAAEgIAAAFBQCAP8C/wAAAAAAEAClAACAAR0AAwEIAAEgIAAAFBQCAP8C/wAAAAAAEgClAACAAQ==",
+                "sceneCode": 2203,
+                "specialEffect": [],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 712,
+                "scenceName": "F",
+                "scenceParam": "Ax1QAAABAAH/5wCAFBQDzRQC+RH/BHr/AACAAACAAB1VAAABAAH/6ACAFBQDzBQCdwD/AP+BAACAAACAACMkAQAHAAH/zgCAFBQD5xQE/wCW/wAA//cAAGX/AACAAACAAA==",
+                "sceneCode": 2205,
+                "specialEffect": [],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 713,
+                "scenceName": "G",
+                "scenceParam": "BCYAAAABAAEaAACAFBQAgBQFx1L/AAAAAAAAAAAAAAAAAACAAACAACwAAzIKAAKSAACAFBQSAACoFBQBABQFAP//AAAAAAAAyl3/AAAAAACAAACAASkAAQAmAAH/AACAFBQDgBQGAP+eAAAAAAAAAIT/AAAAAAAAFAD7AACAAi8AAQAyAgL/AACqFBQAAAC4FBQC8hQGAAD/AAAAAAAAAP9bAAAAAAAAAACAEgD9BA==",
+                "sceneCode": 2206,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11295,
+                    "scenceParam": "BCYAAAABAAEaAACAFBQAgBQFx1L/AAAAAAAAAAAAAAAAAACAAACAACwAAzIKAAKSAACAFBQSAACoFBQBABQFAP//AAAAAAAAyl3/AAAAAACAAACAASkAAQAmAAH/AACAFBQDgBQGAP+eAAAAAAAAAIT/AAAAAAAAFAD7AACAAi8AAQAyAgL/AACqFBQAAAC4FBQC8hQGAAD/AAAAAAAAAP9bAAAAAAAAAACAEgD9BA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\":[234,242,251],\"defaultIndex\":2,\"page\":2},{\"moveAll\":[234,244,253],\"page\":3,\"defaultIndex\":2}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31295,
+                    "scenceParam": "BCYAAAABAAEaAACAFBQAgBQFx1L/AAAAAAAAAAAAAAAAAACAAACAACwAAzIKAAKSAACAFBQSAACoFBQBABQFAP//AAAAAAAAyl3/AAAAAACAAACAASkAAQAmAAH/AACAFBQDgBQGAP+eAAAAAAAAAIT/AAAAAAAAFAD7AACAAi8AAQAyAgL/AACqFBQAAAC4FBQC8hQGAAD/AAAAAAAAAP9bAAAAAAAAAACAEgD9BA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\": [234, 252, 251], \"defaultIndex\": 3, \"page\": 2}, {\"moveAll\": [234, 254, 253], \"page\": 3, \"defaultIndex\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 182,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/f0f15e6fa606f2650cdc2620c9b6ae9a-new_light_btn_scenes_breath%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/1d7ec728c57dd38a1ed09ddf8c7e374a-new_light_btn_scenes_breath_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/5ef22de7fbdd369cc8b799142c0f1339-new_light_btn_scenes_breath_dark%403x.png"
+            ],
+            "sceneName": "Breathe",
+            "analyticName": "Breathe",
+            "sceneType": 0,
+            "sceneCode": 10,
+            "scenceCategoryId": 8,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 164,
+                "scenceName": "",
+                "scenceParam": "",
+                "sceneCode": 10,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 0,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 183,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/039db5a9eda3f1eabd16f84b13e660c5-new_light_btn_scenes_vivid%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/1c11a305964105448a7841dd2835a847-new_light_btn_scenes_vivid_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/406221ccf9e763e73098cfb3da08edbd-new_light_btn_scenes_vivid_dark%403x.png"
+            ],
+            "sceneName": "Energetic",
+            "analyticName": "Energetic",
+            "sceneType": 0,
+            "sceneCode": 16,
+            "scenceCategoryId": 8,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 165,
+                "scenceName": "A",
+                "scenceParam": "",
+                "sceneCode": 16,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 0,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 1768,
+                "scenceName": "B",
+                "scenceParam": "BSBQAAADAAH//wCAFBQDgBQDAAD/wwD/AP+6FgD+AACABCBVAAADAAH//wCAFBQDgBQDAAD/wwD/AP+6FAD+AACABCAAAAABAAE0NACAFBQD9hQDAP/iAAD/5wD/AACAAACAASBVAAADAAH//wCAFBQDgBQDAAD/wwD/AP+6FgD+AACABCBQAAADAAH//wCAFBQDgBQDAAD/wwD/AP+6FAD+AACABA==",
+                "sceneCode": 2286,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11296,
+                    "scenceParam": "BSBQAAADAAH//wCAFBQDgBQDAAD/wwD/AP+6FgD+AACABCBVAAADAAH//wCAFBQDgBQDAAD/wwD/AP+6FAD+AACABCAAAAABAAE0NACAFBQD9hQDAP/iAAD/5wD/AACAAACAASBVAAADAAH//wCAFBQDgBQDAAD/wwD/AP+6FgD+AACABCBQAAADAAH//wCAFBQDgBQDAAD/wwD/AP+6FAD+AACABA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\":0,\"moveIn\":[242,249,252,254],\"defaultIndex\":3},{\"moveIn\":[242,249,252,254],\"defaultIndex\":3,\"page\":1},{\"moveIn\":[242,249,252,254],\"page\":3,\"defaultIndex\":3},{\"moveIn\":[242,249,252,254],\"page\":4,\"defaultIndex\":3}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31296,
+                    "scenceParam": "BSBQAAADAAH//wCAFBQDgBQDAAD/wwD/AP+6FgD+AACABCBVAAADAAH//wCAFBQDgBQDAAD/wwD/AP+6FAD+AACABCAAAAABAAE0NACAFBQD9hQDAP/iAAD/5wD/AACAAACAASBVAAADAAH//wCAFBQDgBQDAAD/wwD/AP+6FgD+AACABCBQAAADAAH//wCAFBQDgBQDAAD/wwD/AP+6FAD+AACABA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\": 0, \"moveIn\": [242, 249, 252, 254], \"defaultIndex\": 4}, {\"moveIn\": [242, 249, 252, 254], \"defaultIndex\": 4, \"page\": 1}, {\"moveIn\": [242, 249, 252, 254], \"page\": 3, \"defaultIndex\": 4}, {\"moveIn\": [242, 249, 252, 254], \"page\": 4, \"defaultIndex\": 4}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 1770,
+                "scenceName": "C",
+                "scenceParam": "AxoAAAABAAH/AACAFBQAgBQBCwf+AACAAACAABoAAAABAAH/AACAFBQAgBQB//T1FQHaAACAABoAAAABAAEMAAD/FBQA/xQB/wYOFAH/EAHmAQ==",
+                "sceneCode": 2288,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11297,
+                    "scenceParam": "AxoAAAABAAH/AACAFBQAgBQBCwf+AACAAACAABoAAAABAAH/AACAFBQAgBQB//T1FQHaAACAABoAAAABAAEMAAD/FBQA/xQB/wYOFAH/EAHmAQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":1,\"page\":1,\"moveIn\":[239,218,249]},{\"defaultIndex\":1,\"moveAll\":[230,230,249],\"moveIn\":[252,255,255],\"page\":2}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31297,
+                    "scenceParam": "AxoAAAABAAH/AACAFBQAgBQBCwf+AACAAACAABoAAAABAAH/AACAFBQAgBQB//T1FQHaAACAABoAAAABAAEMAAD/FBQA/xQB/wYOFAH/EAHmAQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\": 2, \"page\": 1, \"moveIn\": [239, 228, 249]}, {\"defaultIndex\": 2, \"moveAll\": [230, 240, 249], \"moveIn\": [252, 255, 255], \"page\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 2884,
+                "scenceName": "D",
+                "scenceParam": "AykAAAAGAgH//wOAFBQCgBQG/wAA/38A//8AAP8AAAD/iwD/EAD/AACAACkAAAAMAgH/AAOAFBQCwBQG/wAA/38A//8AAP8AAAD/iwD/EgD/AACAACkAAhkGAAH/fwCAFBQB/xQG/wAA/38A////AP8AAAD/iwD/EQD+AACAAA==",
+                "sceneCode": 2501,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11298,
+                    "scenceParam": "AykAAAAGAgH//wOAFBQCgBQG/wAA/38A//8AAP8AAAD/iwD/EAD/AACAACkAAAAMAgH/AAOAFBQCwBQG/wAA/38A//8AAP8AAAD/iwD/EgD/AACAACkAAhkGAAH/fwCAFBQB/xQG/wAA/38A////AP8AAAD/iwD/EQD+AACAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":2,\"page\":0,\"moveIn\":[249,252,255]},{\"defaultIndex\":2,\"page\":1,\"moveIn\":[249,252,255]},{\"page\":2,\"moveIn\":[249,252,254],\"defaultIndex\":2,\"color\":[252,255,255]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31298,
+                    "scenceParam": "AykAAAAGAgH//wOAFBQCgBQG/wAA/38A//8AAP8AAAD/iwD/EAD/AACAACkAAAAMAgH/AAOAFBQCwBQG/wAA/38A//8AAP8AAAD/iwD/EgD/AACAACkAAhkGAAH/fwCAFBQB/xQG/wAA/38A////AP8AAAD/iwD/EQD+AACAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\": 3, \"page\": 0, \"moveIn\": [249, 252, 255]}, {\"defaultIndex\": 3, \"page\": 1, \"moveIn\": [249, 252, 255]}, {\"page\": 2, \"moveIn\": [249, 252, 254], \"defaultIndex\": 3, \"color\": [255, 255, 255]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 184,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/1976004359f086fac518b4a84fe76b80-new_light_btn_scenes_excited%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/3d8c6c9f7e99851fdb86b0e75b9a124d-new_light_btn_scenes_excited_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/fa2e3f25853412f23184c3d6ef1942d7-new_light_btn_scenes_excited_dark%403x.png"
+            ],
+            "sceneName": "Excited",
+            "analyticName": "Excited",
+            "sceneType": 2,
+            "sceneCode": 240,
+            "scenceCategoryId": 8,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 166,
+                "scenceName": "A",
+                "scenceParam": "BSAZAQAFAAH/AAHwDwUBljID/wAAiwD//ywAEQGAAAAAACAXAQAFAAH/AAHwDwUBljID//8A/38AAP8AEQGAAAAAACAVAQAFAAH/AAHwDwUBljIDAP8AAP//////EQGAAAAAACATAQAFAAH/AAHwDwUBljIDAAD/iwD//AD/EQGAAAAAACARAQAFAAH/AAPwDwUBljIDiwD//38A//8AEQGAAAAAAA==",
+                "sceneCode": 240,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11299,
+                    "scenceParam": "BSAZAQAFAAH/AAHwDwUBljID/wAAiwD//ywAEQGAAAAAACAXAQAFAAH/AAHwDwUBljID//8A/38AAP8AEQGAAAAAACAVAQAFAAH/AAHwDwUBljIDAP8AAP//////EQGAAAAAACATAQAFAAH/AAHwDwUBljIDAAD/iwD//AD/EQGAAAAAACARAQAFAAH/AAPwDwUBljIDiwD//38A//8AEQGAAAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":1,\"bright\":[{\"brightValue\":[204,240,252],\"brightPage\":\"0\"}],\"page\":0},{\"page\":1,\"defaultIndex\":1,\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[204,240,255]}]},{\"bright\":[{\"brightValue\":[204,240,252],\"brightPage\":\"0\"}],\"page\":2,\"defaultIndex\":1},{\"bright\":[{\"brightValue\":[204,240,255],\"brightPage\":\"0\"}],\"page\":3,\"defaultIndex\":1},{\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[204,240,252]}],\"defaultIndex\":1,\"page\":4}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31299,
+                    "scenceParam": "BSAZAQAFAAH/AAHwDwUBljID/wAAiwD//ywAEQGAAAAAACAXAQAFAAH/AAHwDwUBljID//8A/38AAP8AEQGAAAAAACAVAQAFAAH/AAHwDwUBljIDAP8AAP//////EQGAAAAAACATAQAFAAH/AAHwDwUBljIDAAD/iwD//AD/EQGAAAAAACARAQAFAAH/AAPwDwUBljIDiwD//38A//8AEQGAAAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\": 2, \"bright\": [{\"brightValue\": [204, 250, 252], \"brightPage\": \"0\"}], \"page\": 0}, {\"page\": 1, \"defaultIndex\": 2, \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [204, 250, 255]}]}, {\"bright\": [{\"brightValue\": [204, 250, 252], \"brightPage\": \"0\"}], \"page\": 2, \"defaultIndex\": 2}, {\"bright\": [{\"brightValue\": [204, 250, 255], \"brightPage\": \"0\"}], \"page\": 3, \"defaultIndex\": 2}, {\"bright\": [{\"brightPage\": \"0\", \"brightValue\": [204, 250, 252]}], \"defaultIndex\": 2, \"page\": 4}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 244,
+                "scenceName": "B",
+                "scenceParam": "ASkAAhkBAAH/AAD//wEA/xQGiwD/AAD/AP//AP8A//8A/38AEQD9EQH8AA==",
+                "sceneCode": 2035,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11300,
+                    "scenceParam": "ASkAAhkBAAH/AAD//wEA/xQGiwD/AAD/AP//AP8A//8A/38AEQD9EQH8AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\":0,\"moveIn\":[242,249,252,255],\"defaultIndex\":1}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31300,
+                    "scenceParam": "ASkAAhkBAAH/AAD//wEA/xQGiwD/AAD/AP//AP8A//8A/38AEQD9EQH8AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\": 0, \"moveIn\": [242, 249, 252, 255], \"defaultIndex\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 375,
+                "scenceName": "C",
+                "scenceParam": "AikAAQAyAAH//wCAFBQBxRQG/wAAAP8AAAD//wAAAP8AAAD/FgH4EgE4ACkAAQAyAAH//wCAFBQBxRQG/wAAAP8AAAD//wAAAP8AAAD/FAH4EAE4AA==",
+                "sceneCode": 2108,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11301,
+                    "scenceParam": "AikAAQAyAAH//wCAFBQBxRQG/wAAAP8AAAD//wAAAP8AAAD/FgH4EgE4ACkAAQAyAAH//wCAFBQBxRQG/wAAAP8AAAD//wAAAP8AAAD/FAH4EAE4AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\":0,\"defaultIndex\":1,\"moveIn\":[239,247,252]},{\"moveIn\":[239,247,252],\"page\":1,\"defaultIndex\":1}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31301,
+                    "scenceParam": "AikAAQAyAAH//wCAFBQBxRQG/wAAAP8AAAD//wAAAP8AAAD/FgH4EgE4ACkAAQAyAAH//wCAFBQBxRQG/wAAAP8AAAD//wAAAP8AAAD/FAH4EAE4AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\": 0, \"defaultIndex\": 2, \"moveIn\": [239, 247, 252]}, {\"moveIn\": [239, 247, 252], \"page\": 1, \"defaultIndex\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 185,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/a7aabaa18ba756c375d05173235e0daf-new_light_btn_scenes_happy%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/6f38e6c06f921e885e27cd74c1420bcf-new_light_btn_scenes_happy_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/9388e360ba823c5ee9ef805ba9780970-new_light_btn_scenes_happy_dark%403x.png"
+            ],
+            "sceneName": "Happy",
+            "analyticName": "Happy",
+            "sceneType": 2,
+            "sceneCode": 241,
+            "scenceCategoryId": 8,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 167,
+                "scenceName": "A",
+                "scenceParam": "BSkAAAAIAAH/AAP/ZGQCADIG/wAA/38A//8AAP//AAD/AP8AEgD/AAAAAhoRAAABAgH/AAAAAAAA/zIBiwD/AAAAEgH/ARoTAAABAgH/AAAAAAAA/zIBAAD/AAAAEgH/ARoVAAABAgH/AAAAAAAA/zIBAP8AAAAAEgH/ARoVAAABAgH/AAAAAAAA/zIBAP//AAAAEgH/AQ==",
+                "sceneCode": 241,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11302,
+                    "scenceParam": "BSkAAAAIAAH/AAP/ZGQCADIG/wAA/38A//8AAP//AAD/AP8AEgD/AAAAAhoRAAABAgH/AAAAAAAA/zIBiwD/AAAAEgH/ARoTAAABAgH/AAAAAAAA/zIBAAD/AAAAEgH/ARoVAAABAgH/AAAAAAAA/zIBAP8AAAAAEgH/ARoVAAABAgH/AAAAAAAA/zIBAP//AAAAEgH/AQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\":[237,244,252,255],\"page\":0,\"defaultIndex\":2},{\"defaultIndex\":2,\"page\":1,\"moveAll\":[237,244,252,255]},{\"defaultIndex\":2,\"moveAll\":[237,244,252,255],\"page\":2},{\"moveAll\":[237,244,252,255],\"page\":3,\"defaultIndex\":2},{\"page\":4,\"moveAll\":[237,244,252,255],\"defaultIndex\":2}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31302,
+                    "scenceParam": "BSkAAAAIAAH/AAP/ZGQCADIG/wAA/38A//8AAP//AAD/AP8AEgD/AAAAAhoRAAABAgH/AAAAAAAA/zIBiwD/AAAAEgH/ARoTAAABAgH/AAAAAAAA/zIBAAD/AAAAEgH/ARoVAAABAgH/AAAAAAAA/zIBAP8AAAAAEgH/ARoVAAABAgH/AAAAAAAA/zIBAP//AAAAEgH/AQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\": [237, 244, 252, 255], \"page\": 0, \"defaultIndex\": 3}, {\"defaultIndex\": 3, \"page\": 1, \"moveAll\": [237, 244, 252, 255]}, {\"defaultIndex\": 3, \"moveAll\": [237, 244, 252, 255], \"page\": 2}, {\"moveAll\": [237, 244, 252, 255], \"page\": 3, \"defaultIndex\": 3}, {\"page\": 4, \"moveAll\": [237, 244, 252, 255], \"defaultIndex\": 3}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 810,
+                "scenceName": "B",
+                "scenceParam": "AyMAAwEBAAH/AACAFBQD/wgE/+M1/9cA/94A/7UAFAD/AACAACMAAwEBAAH/AACAFBQD/wgE/+M1/9cA/94A/7UAFgD/AACAABoAAAABAAH/AAP/AjwAghQB//8AAACAAACAAA==",
+                "sceneCode": 2221,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11303,
+                    "scenceParam": "AyMAAwEBAAH/AACAFBQD/wgE/+M1/9cA/94A/7UAFAD/AACAACMAAwEBAAH/AACAFBQD/wgE/+M1/9cA/94A/7UAFgD/AACAABoAAAABAAH/AAP/AjwAghQB//8AAACAAACAAA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":2,\"moveIn\":[239,247,252,255],\"page\":0},{\"defaultIndex\":2,\"moveIn\":[239,247,252,255],\"page\":1},{\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[204,229,255,255]}],\"page\":2,\"defaultIndex\":2}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31303,
+                    "scenceParam": "AyMAAwEBAAH/AACAFBQD/wgE/+M1/9cA/94A/7UAFAD/AACAACMAAwEBAAH/AACAFBQD/wgE/+M1/9cA/94A/7UAFgD/AACAABoAAAABAAH/AAP/AjwAghQB//8AAACAAACAAA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\": 3, \"moveIn\": [239, 247, 252, 255], \"page\": 0}, {\"defaultIndex\": 3, \"moveIn\": [239, 247, 252, 255], \"page\": 1}, {\"bright\": [{\"brightPage\": \"0\", \"brightValue\": [204, 229, 255, 255]}], \"page\": 2, \"defaultIndex\": 3}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 186,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/85fe8cf6553682bf76abc6493cae4948-new_light_btn_scenes_passionate%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/357447e16b66908ed5514d11067e7270-new_light_btn_scenes_passionate_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/1d9645205249a2a0a73a6bfabe6ddf62-new_light_btn_scenes_passionate_dark%403x.png"
+            ],
+            "sceneName": "Enthusiastic",
+            "analyticName": "Enthusiastic",
+            "sceneType": 2,
+            "sceneCode": 242,
+            "scenceCategoryId": 8,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 168,
+                "scenceName": "",
+                "scenceParam": "BRogAQAFAgH/KAHwAAACADIB/wAAEAD+AAAAABoiAQAFAgH/KAHwAAACADIB/38AEAD+AAAAACAkAQAFAgH/KAHwAAACADID//8A/wAAAAD/EAD+AAAAACAmAQAFAgH/KAHwAAACADIDf/8AAP//xwD/EAD+AAAAACMoAQAFAgH/KAHwAAACADIEAP8A/38AAAAAAAD/EAD+AAAAAA==",
+                "sceneCode": 242,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11304,
+                    "scenceParam": "BRogAQAFAgH/KAHwAAACADIB/wAAEAD+AAAAABoiAQAFAgH/KAHwAAACADIB/38AEAD+AAAAACAkAQAFAgH/KAHwAAACADID//8A/wAAAAD/EAD+AAAAACAmAQAFAgH/KAHwAAACADIDf/8AAP//xwD/EAD+AAAAACMoAQAFAgH/KAHwAAACADIEAP8A/38AAAAAAAD/EAD+AAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\":0,\"defaultIndex\":1,\"moveIn\":[234,249,252]},{\"defaultIndex\":1,\"moveIn\":[234,249,252],\"page\":1},{\"defaultIndex\":1,\"moveIn\":[234,249,252],\"page\":2},{\"moveIn\":[234,249,252],\"defaultIndex\":1,\"page\":3},{\"moveIn\":[234,249,252],\"page\":4,\"defaultIndex\":1}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31304,
+                    "scenceParam": "BRogAQAFAgH/KAHwAAACADIB/wAAEAD+AAAAABoiAQAFAgH/KAHwAAACADIB/38AEAD+AAAAACAkAQAFAgH/KAHwAAACADID//8A/wAAAAD/EAD+AAAAACAmAQAFAgH/KAHwAAACADIDf/8AAP//xwD/EAD+AAAAACMoAQAFAgH/KAHwAAACADIEAP8A/38AAAAAAAD/EAD+AAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\": 0, \"defaultIndex\": 2, \"moveIn\": [234, 249, 252]}, {\"defaultIndex\": 2, \"moveIn\": [234, 249, 252], \"page\": 1}, {\"defaultIndex\": 2, \"moveIn\": [234, 249, 252], \"page\": 2}, {\"moveIn\": [234, 249, 252], \"defaultIndex\": 2, \"page\": 3}, {\"moveIn\": [234, 249, 252], \"page\": 4, \"defaultIndex\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 187,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/788ded9e4e379df9a8c10bc658638f1d-new_light_btn_scenes_deep%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/a98e56be23c1f30cd601d98ccd02024b-new_light_btn_scenes_deep_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/871dfe9af73c0b58ce4a8b297507ed9c-new_light_btn_scenes_deep_dark%403x.png"
+            ],
+            "sceneName": "Profound",
+            "analyticName": "Profound",
+            "sceneType": 2,
+            "sceneCode": 243,
+            "scenceCategoryId": 8,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 169,
+                "scenceName": "",
+                "scenceParam": "AiMAAAAKAgH/CgIAAAACAAAEAAD/AHr/AMf/AP//EAH6AAAAACMAAAAKAgH/CgIAAAACAAAEAAD/AHH/ALL/AP//EgH6AAAAAA==",
+                "sceneCode": 243,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11305,
+                    "scenceParam": "AiMAAAAKAgH/CgIAAAACAAAEAAD/AHr/AMf/AP//EAH6AAAAACMAAAAKAgH/CgIAAAACAAAEAAD/AHH/ALL/AP//EgH6AAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\":[229,242,249,252],\"page\":0,\"defaultIndex\":2},{\"defaultIndex\":2,\"page\":1,\"moveIn\":[229,242,249,252]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31305,
+                    "scenceParam": "AiMAAAAKAgH/CgIAAAACAAAEAAD/AHr/AMf/AP//EAH6AAAAACMAAAAKAgH/CgIAAAACAAAEAAD/AHH/ALL/AP//EgH6AAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\": [229, 242, 249, 252], \"page\": 0, \"defaultIndex\": 3}, {\"defaultIndex\": 3, \"page\": 1, \"moveIn\": [229, 242, 249, 252]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 188,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/71e677a1277e9a9d11c0fa81035b71d0-new_light_btn_scenes_mysterious%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/4687c3d680d0fd5675957fefdcf390e0-new_light_btn_scenes_mysterious_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/abe833fdcd34644837fd900e01c9c213-new_light_btn_scenes_mysterious_dark%403x.png"
+            ],
+            "sceneName": "Mysterious",
+            "analyticName": "Mysterious",
+            "sceneType": 2,
+            "sceneCode": 244,
+            "scenceCategoryId": 8,
+            "popUpPrompt": 2,
+            "scenesHint": "Siren:Those with epilepsy may experience discomfort when using this Scene mode. Exercise caution during use.",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 170,
+                "scenceName": "A",
+                "scenceParam": "AikAAAABAAH/AAH/ZGQA/AMG/wAAAP8AAAD//38A//8AiwD/AAAAAAAAAikAAAAIAAH/AAP/ZGQCADIG/3D//38A//8AAP//AKD/AP8AEgD/AAAAAg==",
+                "sceneCode": 244,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11306,
+                    "scenceParam": "AikAAAABAAH/AAH/ZGQA/AMG/wAAAP8AAAD//38A//8AiwD/AAAAAAAAAikAAAAIAAH/AAP/ZGQCADIG/3D//38A//8AAP//AKD/AP8AEgD/AAAAAg==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"color\":[239,247,252,252],\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[252,255,255,255]}],\"page\":0,\"defaultIndex\":2},{\"defaultIndex\":2,\"page\":1,\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[252,255,255,255]}],\"moveIn\":[242,249,252,255]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31306,
+                    "scenceParam": "AikAAAABAAH/AAH/ZGQA/AMG/wAAAP8AAAD//38A//8AiwD/AAAAAAAAAikAAAAIAAH/AAP/ZGQCADIG/3D//38A//8AAP//AKD/AP8AEgD/AAAAAg==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"color\": [239, 247, 252, 252], \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [252, 255, 255, 255]}], \"page\": 0, \"defaultIndex\": 3}, {\"defaultIndex\": 3, \"page\": 1, \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [252, 255, 255, 255]}], \"moveIn\": [242, 249, 252, 255]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 245,
+                "scenceName": "B",
+                "scenceParam": "ASMUAQAFAAH/AAL//5YB/xcEAAD//+Xu/9/m/6/jAACAEQ3/AA==",
+                "sceneCode": 2036,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11307,
+                    "scenceParam": "ASMUAQAFAAH/AAL//5YB/xcEAAD//+Xu/9/m/6/jAACAEQ3/AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":1,\"moveAll\":[247,252,255],\"page\":0}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31307,
+                    "scenceParam": "ASMUAQAFAAH/AAL//5YB/xcEAAD//+Xu/9/m/6/jAACAEQ3/AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\": 2, \"moveAll\": [247, 252, 255], \"page\": 0}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 189,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/9e6f0220dd75c1ea863a0ef9b613b97c-new_light_btn_scenes_quiet%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/d6cbf0cd40f5939f4cb17d7f32e51583-new_light_btn_scenes_quiet_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/5f20331777a395d06e62be31d2d29449-new_light_btn_scenes_quiet_dark%403x.png"
+            ],
+            "sceneName": "Quiet",
+            "analyticName": "Quiet",
+            "sceneType": 2,
+            "sceneCode": 245,
+            "scenceCategoryId": 8,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 171,
+                "scenceName": "A",
+                "scenceParam": "ASAAAAAIAgH/MgHIMhQC+jIDbv8A1f8A1f8AEQKAAAAAAA==",
+                "sceneCode": 245,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 811,
+                "scenceName": "B",
+                "scenceParam": "AywAAxQAAAP/AACzFBQAAADHFBT/AACAFBQDgBQDAP//AAAAiwD/EQD9AAD+Ah1VAxkAAAH/AACAFBQDABQCAAD/AAAAEQD+AACAASkAAw8oAAH/AACAFBQD/hQG9wD/AAAAIAD/AAAA/+8AAAAAFwD9AACABA==",
+                "sceneCode": 2222,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11308,
+                    "scenceParam": "AywAAxQAAAP/AACzFBQAAADHFBT/AACAFBQDgBQDAP//AAAAiwD/EQD9AAD+Ah1VAxkAAAH/AACAFBQDABQCAAD/AAAAEQD+AACAASkAAw8oAAH/AACAFBQD/hQG9wD/AAAAIAD/AAAA/+8AAAAAFwD9AACABA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\":[242,249,253],\"page\":0,\"defaultIndex\":2},{\"moveIn\":[242,249,252],\"defaultIndex\":2,\"page\":1},{\"defaultIndex\":2,\"page\":2,\"moveIn\":[242,249,253]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31308,
+                    "scenceParam": "AywAAxQAAAP/AACzFBQAAADHFBT/AACAFBQDgBQDAP//AAAAiwD/EQD9AAD+Ah1VAxkAAAH/AACAFBQDABQCAAD/AAAAEQD+AACAASkAAw8oAAH/AACAFBQD/hQG9wD/AAAAIAD/AAAA/+8AAAAAFwD9AACABA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\": [242, 249, 253], \"page\": 0, \"defaultIndex\": 3}, {\"moveIn\": [242, 249, 252], \"defaultIndex\": 3, \"page\": 1}, {\"defaultIndex\": 3, \"page\": 2, \"moveIn\": [242, 249, 253]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 190,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/f2c4ff4bbbf3c887f8f5068c70f39cc3-new_light_btn_scenes_miss%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/980385f46ce04abd2055ad443e04d3fc-new_light_btn_scenes_miss_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/c1460de5bbbe3d70aaa18bdc63adbc89-new_light_btn_scenes_miss_dark%403x.png"
+            ],
+            "sceneName": "Longing",
+            "analyticName": "Longing",
+            "sceneType": 2,
+            "sceneCode": 246,
+            "scenceCategoryId": 8,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 172,
+                "scenceName": "",
+                "scenceParam": "AiMAAAACAgH/MgHIMlAB0zIEAAD/AHr/swCb/zP/AAAAAAAAACMAAg8FAgH/CgPIMjIByDIEjAD/AHH/iwD//0n/FAGWAAAAAA==",
+                "sceneCode": 246,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 191,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/b1a0b7ac1f7beaec1895df316ebf9383-new_light_btn_scenes_warm_hot%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/27cdbdec24b8f8056ae4afbbe954e7a8-new_light_btn_scenes_warm_hot_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/d40cf8be5dc7c1e20edac7591ed2e2a0-new_light_btn_scenes_warm_hot_dark%403x.png"
+            ],
+            "sceneName": "Warm",
+            "analyticName": "Warm",
+            "sceneType": 2,
+            "sceneCode": 247,
+            "scenceCategoryId": 8,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 173,
+                "scenceName": "A",
+                "scenceParam": "AyNQAQAPAgH/CgIAAAACAAAE/wAA/1oA/3gA5QA2EAD6AAAAACMAAQAPAgH/CgIAAAACAAAE/wAA/1oA/3gA8gAcEAD6AAAAABoAAAABAgGWMgAAAAAA+jIB/4H/EQCAAAAAAA==",
+                "sceneCode": 247,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11309,
+                    "scenceParam": "AyNQAQAPAgH/CgIAAAACAAAE/wAA/1oA/3gA5QA2EAD6AAAAACMAAQAPAgH/CgIAAAACAAAE/wAA/1oA/3gA8gAcEAD6AAAAABoAAAABAgGWMgAAAAAA+jIB/4H/EQCAAAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":1,\"page\":0,\"moveIn\":[242,250,252]},{\"defaultIndex\":1,\"moveIn\":[242,250,252],\"page\":1}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31309,
+                    "scenceParam": "AyNQAQAPAgH/CgIAAAACAAAE/wAA/1oA/3gA5QA2EAD6AAAAACMAAQAPAgH/CgIAAAACAAAE/wAA/1oA/3gA8gAcEAD6AAAAABoAAAABAgGWMgAAAAAA+jIB/4H/EQCAAAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\": 2, \"page\": 0, \"moveIn\": [242, 250, 252]}, {\"defaultIndex\": 2, \"moveIn\": [242, 250, 252], \"page\": 1}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 246,
+                "scenceName": "B",
+                "scenceParam": "AyBQAQAUAAH//wAAFBQAABQD/1QHAAAA/2oHFQD6AACAACBVAQAUAAH//wAAFBQAABQD/1QHAAAA/2oHFwD6AACAABoAAQAyAgGPPgH/FBQAABQB/1QHBwD9AACAAA==",
+                "sceneCode": 2037,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11310,
+                    "scenceParam": "AyBQAQAUAAH//wAAFBQAABQD/1QHAAAA/2oHFQD6AACAACBVAQAUAAH//wAAFBQAABQD/1QHAAAA/2oHFwD6AACAABoAAQAyAgGPPgH/FBQAABQB/1QHBwD9AACAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\":[242,250,252],\"page\":0,\"defaultIndex\":1},{\"page\":1,\"moveIn\":[242,250,252],\"defaultIndex\":1}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31310,
+                    "scenceParam": "AyBQAQAUAAH//wAAFBQAABQD/1QHAAAA/2oHFQD6AACAACBVAQAUAAH//wAAFBQAABQD/1QHAAAA/2oHFwD6AACAABoAAQAyAgGPPgH/FBQAABQB/1QHBwD9AACAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\": [242, 250, 252], \"page\": 0, \"defaultIndex\": 2}, {\"page\": 1, \"moveIn\": [242, 250, 252], \"defaultIndex\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 192,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/b189a3914092401402ab5c64a1a22ef2-new_light_btn_scenes_accumulation%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/cf438ec7a2f4fa7f65bf0c38c922c13f-new_light_btn_scenes_accumulation_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/a223d457804c58ad35c0845f5245722e-new_light_btn_scenes_accumulation_dark%403x.png"
+            ],
+            "sceneName": "Stacking",
+            "analyticName": "Stacking",
+            "sceneType": 2,
+            "sceneCode": 248,
+            "scenceCategoryId": 8,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 174,
+                "scenceName": "",
+                "scenceParam": "AiAAAAABAAH//wAAAAAAyDID/wAAAP8AAAD/FADOAAAAACAAAQABAAH//wAAAAAAyDID/wAAAP8AAAD/EgD/AAAAAA==",
+                "sceneCode": 248,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 229,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/fdf887275d58c7a0eac4cfa159b582d5-new_light_btn_scenes_release%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/c51e1d38c634f3bac852cc8cf1ad3d3b-new_light_btn_scenes_release_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/c43fc29b501ac75471336978eb00d2ae-new_light_btn_scenes_release_dark%403x.png"
+            ],
+            "sceneName": "Release",
+            "analyticName": "Release",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 209,
+                "scenceName": "A",
+                "scenceParam": "AiZQAQAKAAH/AAAAZAoCyBQFAAD/AP//AP8A//8A/38AFgD/AAAAACZVAQAKAAH/AAAAZAoCyBQFAAD/AP//AP8A//8A/38AFAD/AAAAAA==",
+                "sceneCode": 2018,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11311,
+                    "scenceParam": "AiZQAQAKAAH/AAAAZAoCyBQFAAD/AP//AP8A//8A/38AFgD/AAAAACZVAQAKAAH/AAAAZAoCyBQFAAD/AP//AP8A//8A/38AFAD/AAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\":[242,249,252,255],\"page\":0,\"defaultIndex\":2},{\"moveIn\":[242,249,252,255],\"page\":1,\"defaultIndex\":2}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31311,
+                    "scenceParam": "AiZQAQAKAAH/AAAAZAoCyBQFAAD/AP//AP8A//8A/38AFgD/AAAAACZVAQAKAAH/AAAAZAoCyBQFAAD/AP//AP8A//8A/38AFAD/AAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\": [242, 249, 252, 255], \"page\": 0, \"defaultIndex\": 3}, {\"moveIn\": [242, 249, 252, 255], \"page\": 1, \"defaultIndex\": 3}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 407,
+                "scenceName": "B",
+                "scenceParam": "BSlQAQAUAgH/AAMAFBQDAAEG/wAA/38A//8AAP8AAP//AAD/AACAEAH/ABokAQAKAgH/AAOAFBQDAP8B////AACAAACAACMkAQAFAgH/AAMAFBSDABQEAAAA////AAAA////AACAEAD/ACAlAQAFAgH/AAMAFBQDABQDAAAA////AAAAAACAEgD/AClVAQAUAgH/AAMAFBSDAAEG/wAA/38A//8AAP8AAP//AAD/AACAEgH/AA==",
+                "sceneCode": 2136,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11312,
+                    "scenceParam": "BSlQAQAUAgH/AAMAFBQDAAEG/wAA/38A//8AAP8AAP//AAD/AACAEAH/ABokAQAKAgH/AAOAFBQDAP8B////AACAAACAACMkAQAFAgH/AAMAFBSDABQEAAAA////AAAA////AACAEAD/ACAlAQAFAgH/AAMAFBQDABQDAAAA////AAAAAACAEgD/AClVAQAUAgH/AAMAFBSDAAEG/wAA/38A//8AAP8AAP//AAD/AACAEgH/AA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveAll\":[242,249,252,255],\"page\":0,\"defaultIndex\":2},{\"moveAll\":[242,249,252,255],\"defaultIndex\":2,\"page\":2},{\"defaultIndex\":2,\"moveAll\":[242,249,252,255],\"page\":3},{\"page\":4,\"defaultIndex\":2,\"moveAll\":[242,249,252,255]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31312,
+                    "scenceParam": "BSlQAQAUAgH/AAMAFBQDAAEG/wAA/38A//8AAP8AAP//AAD/AACAEAH/ABokAQAKAgH/AAOAFBQDAP8B////AACAAACAACMkAQAFAgH/AAMAFBSDABQEAAAA////AAAA////AACAEAD/ACAlAQAFAgH/AAMAFBQDABQDAAAA////AAAAAACAEgD/AClVAQAUAgH/AAMAFBSDAAEG/wAA/38A//8AAP8AAP//AAD/AACAEgH/AA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveAll\": [242, 249, 252, 255], \"page\": 0, \"defaultIndex\": 3}, {\"moveAll\": [242, 249, 252, 255], \"defaultIndex\": 3, \"page\": 2}, {\"defaultIndex\": 3, \"moveAll\": [242, 249, 252, 255], \"page\": 3}, {\"page\": 4, \"defaultIndex\": 3, \"moveAll\": [242, 249, 252, 255]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 230,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/scence-img/4d1f1cf8e2f20203d68df90f22633f20-new_light_btn_scenes_liudong%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/scence-img/329cf848bdbf0ea4bcb52bf024e95cfc-new_light_btn_scenes_liudong_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/scence-img/0c2e3e88ccc15c51ac7585df55371be7-new_light_btn_scenes_liudong_dark%403x.png"
+            ],
+            "sceneName": "Flow",
+            "analyticName": "Flow",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 210,
+                "scenceName": "A",
+                "scenceParam": "ASkAAQAyAgH/MgD/MhkB/AAGAP//AKP/AHT/AAAAAAAAAAAAAAAAAAAAAA==",
+                "sceneCode": 2019,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11313,
+                    "scenceParam": "ASkAAQAyAgH/MgD/MhkB/AAGAP//AKP/AHT/AAAAAAAAAAAAAAAAAAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"color\":[242,249,252],\"defaultIndex\":2,\"page\":0}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31313,
+                    "scenceParam": "ASkAAQAyAgH/MgD/MhkB/AAGAP//AKP/AHT/AAAAAAAAAAAAAAAAAAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"color\": [247, 254, 255], \"defaultIndex\": 3, \"page\": 0}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 1766,
+                "scenceName": "B",
+                "scenceParam": "ASkAAAABAAH//wEB//8B+gEGAP//AEz/AAD/AAAAAAAAAAAAAAB/AAB/AQ==",
+                "sceneCode": 2284,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11314,
+                    "scenceParam": "ASkAAAABAAH//wEB//8B+gEGAP//AEz/AAD/AAAAAAAAAAAAAAB/AAB/AQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\":0,\"color\":[242,250,252],\"defaultIndex\":1}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31314,
+                    "scenceParam": "ASkAAAABAAH//wEB//8B+gEGAP//AEz/AAD/AAAAAAAAAAAAAAB/AAB/AQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\": 0, \"color\": [247, 255, 255], \"defaultIndex\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 231,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/03fb118b4a2979d6b4e62c33693e01ab-new_light_btn_scenes_shanxian%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/a23ed8e6fee9a9df2b3263b9cc4e52d8-new_light_btn_scenes_shanxian_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/65209de5e8cbf1293487ef1acf215663-new_light_btn_scenes_shanxian_dark%403x.png"
+            ],
+            "sceneName": "Flash",
+            "analyticName": "Flash",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 211,
+                "scenceName": "",
+                "scenceParam": "ASagAQAKAAH//wAAAAAA/hQF//8A/38A/0UA/wAA2wBIFAH/AAAAAA==",
+                "sceneCode": 2020,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11315,
+                    "scenceParam": "ASagAQAKAAH//wAAAAAA/hQF//8A/38A/0UA/wAA2wBIFAH/AAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\":0,\"defaultIndex\":1,\"moveIn\":[249,252,255]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31315,
+                    "scenceParam": "ASagAQAKAAH//wAAAAAA/hQF//8A/38A/0UA/wAA2wBIFAH/AAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\": 0, \"defaultIndex\": 2, \"moveIn\": [249, 252, 255]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 232,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/1c758817ec1c1574b9b705b48d1a19f1-new_light_btn_scenes_swing%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/4ac3f02da69f1c4ddcab70b7386b20da-new_light_btn_scenes_swing_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/c990a64d21bdec0743fc7a03958bed48-new_light_btn_scenes_swing_dark%403x.png"
+            ],
+            "sceneName": "Swing",
+            "analyticName": "Swing",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 212,
+                "scenceName": "",
+                "scenceParam": "BSMgAQAGAgH/AAD/FBQA/xQE/0EA/4IA1ABX/5YAEQD9AAAAACMiAQAGAgH/AAD/FBQA/xQE/0EA/2MA4wA5/7kAEQD9AAAAACMkAQAGAgH/AAD/FBQA/xQE/0EA/2MA3gBE/7AAEQD9AAAAACMmAQAGAgH/AAD/FBQA/xQE/0EA/5YA1QBV/64AEQD9AAAAACMoAQAGAgH/AAD/FBQA/xQE/0EA/5YA7QAk/7IAEQD9AAAAAA==",
+                "sceneCode": 2021,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11316,
+                    "scenceParam": "BSMgAQAGAgH/AAD/FBQA/xQE/0EA/4IA1ABX/5YAEQD9AAAAACMiAQAGAgH/AAD/FBQA/xQE/0EA/2MA4wA5/7kAEQD9AAAAACMkAQAGAgH/AAD/FBQA/xQE/0EA/2MA3gBE/7AAEQD9AAAAACMmAQAGAgH/AAD/FBQA/xQE/0EA/5YA1QBV/64AEQD9AAAAACMoAQAGAgH/AAD/FBQA/xQE/0EA/5YA7QAk/7IAEQD9AAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"color\":[244,252,255,255],\"defaultIndex\":2,\"page\":0,\"moveIn\":[234,242,249,252]},{\"moveIn\":[234,242,249,252],\"defaultIndex\":2,\"page\":1,\"color\":[244,252,255,255]},{\"page\":2,\"color\":[244,252,255,255],\"moveIn\":[234,242,249,252],\"defaultIndex\":2},{\"defaultIndex\":2,\"moveIn\":[234,242,249,252],\"page\":3,\"color\":[244,252,255,255]},{\"defaultIndex\":2,\"color\":[244,252,255,255],\"page\":4,\"moveIn\":[234,242,249,252]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31316,
+                    "scenceParam": "BSMgAQAGAgH/AAD/FBQA/xQE/0EA/4IA1ABX/5YAEQD9AAAAACMiAQAGAgH/AAD/FBQA/xQE/0EA/2MA4wA5/7kAEQD9AAAAACMkAQAGAgH/AAD/FBQA/xQE/0EA/2MA3gBE/7AAEQD9AAAAACMmAQAGAgH/AAD/FBQA/xQE/0EA/5YA1QBV/64AEQD9AAAAACMoAQAGAgH/AAD/FBQA/xQE/0EA/5YA7QAk/7IAEQD9AAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"color\": [244, 252, 255, 255], \"defaultIndex\": 3, \"page\": 0, \"moveIn\": [234, 242, 249, 252]}, {\"moveIn\": [234, 242, 249, 252], \"defaultIndex\": 3, \"page\": 1, \"color\": [244, 252, 255, 255]}, {\"page\": 2, \"color\": [244, 252, 255, 255], \"moveIn\": [234, 242, 249, 252], \"defaultIndex\": 3}, {\"defaultIndex\": 3, \"moveIn\": [234, 242, 249, 252], \"page\": 3, \"color\": [244, 252, 255, 255]}, {\"defaultIndex\": 3, \"color\": [244, 252, 255, 255], \"page\": 4, \"moveIn\": [234, 242, 249, 252]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 233,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/scence-img/becade52257e679d2d0a401183bc41a8-new_light_btn_scenes_tension%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/scence-img/810ea4cd552e872e01dbdbb31c05469a-new_light_btn_scenes_tension_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/scence-img/1d4cf2e286886a8f52e19b256d2f5829-new_light_btn_scenes_tension_dark%403x.png"
+            ],
+            "sceneName": "Tension",
+            "analyticName": "Tension",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 213,
+                "scenceName": "A",
+                "scenceParam": "AiAAAQAKAgH/FAAAAAACAAADUAAAyAAA/wAAEQH+AAAAACAAAQAKAgH/FAAAAAACAAAD/wAAyAAAUAAAEwH+AAAAAA==",
+                "sceneCode": 2022,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11317,
+                    "scenceParam": "AiAAAQAKAgH/FAAAAAACAAADUAAAyAAA/wAAEQH+AAAAACAAAQAKAgH/FAAAAAACAAAD/wAAyAAAUAAAEwH+AAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\":[242,249,252],\"defaultIndex\":2,\"page\":0},{\"moveIn\":[242,249,252],\"page\":1,\"defaultIndex\":2}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31317,
+                    "scenceParam": "AiAAAQAKAgH/FAAAAAACAAADUAAAyAAA/wAAEQH+AAAAACAAAQAKAgH/FAAAAAACAAAD/wAAyAAAUAAAEwH+AAAAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\": [242, 249, 252], \"defaultIndex\": 3, \"page\": 0}, {\"moveIn\": [242, 249, 252], \"page\": 1, \"defaultIndex\": 3}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 809,
+                "scenceName": "B",
+                "scenceParam": "AhpEAAABAAH//wB/FBQAfxQB/wAAAAB/EQr2AiAAAAABAAFoMAB/FBQBABQDiwD/AAD/iwD/AAB/EABSAQ==",
+                "sceneCode": 2220,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11318,
+                    "scenceParam": "AhpEAAABAAH//wB/FBQAfxQB/wAAAAB/EQr2AiAAAAABAAFoMAB/FBQBABQDiwD/AAD/iwD/AAB/EABSAQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\":0,\"defaultIndex\":1,\"moveAll\":[242,249,252,255]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31318,
+                    "scenceParam": "AhpEAAABAAH//wB/FBQAfxQB/wAAAAB/EQr2AiAAAAABAAFoMAB/FBQBABQDiwD/AAD/iwD/AAB/EABSAQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\": 0, \"defaultIndex\": 2, \"moveAll\": [242, 249, 252, 255]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 250,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/61bc1da93fd05845fcc4735a4afa36b2-new_light_btn_scenes_cheerful%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/866fb58d015f031051e4ab51e3bb0a65-new_light_btn_scenes_cheerful_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/f96fe31abf9687665199079a75e6e2cf-new_light_btn_scenes_cheerful_dark%403x.png"
+            ],
+            "sceneName": "Cheerful",
+            "analyticName": "Cheerful",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 2,
+            "scenesHint": "Siren:Those with epilepsy may experience discomfort when using this Scene mode. Exercise caution during use.",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 247,
+                "scenceName": "",
+                "scenceParam": "Ah0AAAABAAH/fQGAFBQAgBQC/wAAAAD/AACAAACAAC8AAQAyAAL//wCAFBT/AAGAFBQBABQGAP//AAAAAP//AAAAAP//AAAAFQD7AACAAA==",
+                "sceneCode": 2038,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11319,
+                    "scenceParam": "Ah0AAAABAAH/fQGAFBQAgBQC/wAAAAD/AACAAACAAC8AAQAyAAL//wCAFBT/AAGAFBQBABQGAP//AAAAAP//AAAAAP//AAAAFQD7AACAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":1,\"page\":1,\"moveIn\":[242,251,252]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31319,
+                    "scenceParam": "Ah0AAAABAAH/fQGAFBQAgBQC/wAAAAD/AACAAACAAC8AAQAyAAL//wCAFBT/AAGAFBQBABQGAP//AAAAAP//AAAAAP//AAAAFQD7AACAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\": 2, \"page\": 1, \"moveIn\": [242, 251, 252]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 254,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/123895685d4718fb0ab6cb21aaf71586-new_light_btn_scenes_jicu.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/f0c78a209644e427e9d40f2d14832d73-new_light_btn_scenes_jicu_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/b1c0791c1b09109bbf3a34565aaf05a3-new_light_btn_scenes_jicu_dark.png"
+            ],
+            "sceneName": "Rush",
+            "analyticName": "Rush",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 253,
+                "scenceName": "",
+                "scenceParam": "BBpAAAACAAH/AACAFBQAgBQBiwD/EgD/EgD/ABphAAACAAH/AACAFBQAgBQBAAD/EQD/EQD/ARpiAAADAAH/AAAAFBQAgBQBAP//EwD/EwD/ARpkAAABAAH/AACAFBQAgBQB+Af+EAD/EAD/AQ==",
+                "sceneCode": 2072,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11320,
+                    "scenceParam": "BBpAAAACAAH/AACAFBQAgBQBiwD/EgD/EgD/ABphAAACAAH/AACAFBQAgBQBAAD/EQD/EQD/ARpiAAADAAH/AAAAFBQAgBQBAP//EwD/EwD/ARpkAAABAAH/AACAFBQAgBQB+Af+EAD/EAD/AQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveAll\":[249,252,255],\"moveIn\":[249,252,255],\"defaultIndex\":2,\"page\":0},{\"moveAll\":[249,252,255],\"defaultIndex\":2,\"moveIn\":[249,252,255],\"page\":1},{\"moveIn\":[249,252,255],\"page\":2,\"moveAll\":[249,252,255],\"defaultIndex\":2},{\"page\":3,\"defaultIndex\":2,\"moveIn\":[249,252,255],\"moveAll\":[249,252,255]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31320,
+                    "scenceParam": "BBpAAAACAAH/AACAFBQAgBQBiwD/EgD/EgD/ABphAAACAAH/AACAFBQAgBQBAAD/EQD/EQD/ARpiAAADAAH/AAAAFBQAgBQBAP//EwD/EwD/ARpkAAABAAH/AACAFBQAgBQB+Af+EAD/EAD/AQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveAll\":[249,252,255],\"moveIn\":[249,252,255],\"defaultIndex\":2,\"page\":0},{\"moveAll\":[249,252,255],\"defaultIndex\":2,\"moveIn\":[249,252,255],\"page\":1},{\"moveIn\":[249,252,255],\"page\":2,\"moveAll\":[249,252,255],\"defaultIndex\":2},{\"page\":3,\"defaultIndex\":2,\"moveIn\":[249,252,255],\"moveAll\":[249,252,255]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 748,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/0eb99faaafc0cd38a7ceda1037cdf79d-new_light_btn_scenes_heartbeat.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/84de54f4fbfc83cdf70ae5ee2dfaffc7-new_light_btn_scenes_heartbeat_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/e9f9d4815b75d51c4b1c6e82e046c7c2-new_light_btn_scenes_heartbeat_dark.png"
+            ],
+            "sceneName": "Heartbeat",
+            "analyticName": "Heartbeat",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 806,
+                "scenceName": "A",
+                "scenceParam": "ASAAAAABAAH/AALZCgED+BQD/wAAAAAA/wAAAACAEAD/AA==",
+                "sceneCode": 2217,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11321,
+                    "scenceParam": "ASAAAAABAAH/AALZCgED+BQD/wAAAAAA/wAAAACAEAD/AA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":1,\"moveAll\":[244,252,255],\"page\":0}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31321,
+                    "scenceParam": "ASAAAAABAAH/AALZCgED+BQD/wAAAAAA/wAAAACAEAD/AA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\": 2, \"moveAll\": [244, 252, 255], \"page\": 0}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 812,
+                "scenceName": "B",
+                "scenceParam": "BBoAAwEDAAH/AAHNMhQAABQB/wAAEADgAACAABoAAwEEAAH/AAHNMhQAABQBAAD/EADlAACAARoAAwEFAAH/AAHNMhQAABQB/wbpEADpAACAABoAAAABAAENDQAAFBQAABQB////AACAAACAAA==",
+                "sceneCode": 2223,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11322,
+                    "scenceParam": "BBoAAwEDAAH/AAHNMhQAABQB/wAAEADgAACAABoAAwEEAAH/AAHNMhQAABQBAAD/EADlAACAARoAAwEFAAH/AAHNMhQAABQB/wbpEADpAACAABoAAAABAAENDQAAFBQAABQB////AACAAACAAA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\":0,\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[201,205,205]}],\"defaultIndex\":1,\"moveIn\":[216,224,252]},{\"page\":1,\"defaultIndex\":1,\"moveIn\":[216,229,252],\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[201,205,205]}]},{\"moveIn\":[214,233,252],\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[201,205,205]}],\"defaultIndex\":1,\"page\":2}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31322,
+                    "scenceParam": "BBoAAwEDAAH/AAHNMhQAABQB/wAAEADgAACAABoAAwEEAAH/AAHNMhQAABQBAAD/EADlAACAARoAAwEFAAH/AAHNMhQAABQB/wbpEADpAACAABoAAAABAAENDQAAFBQAABQB////AACAAACAAA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\": 0, \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [201, 215, 205]}], \"defaultIndex\": 2, \"moveIn\": [216, 234, 252]}, {\"page\": 1, \"defaultIndex\": 2, \"moveIn\": [216, 239, 252], \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [201, 215, 205]}]}, {\"moveIn\": [214, 243, 252], \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [201, 215, 205]}], \"defaultIndex\": 2, \"page\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 749,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/81025de451178a790520372251cfed74-new_light_btn_scenes_fengkuang.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/eca2bb5df5012eef6e28dcd94ac6022d-new_light_btn_scenes_fengkuang_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/34c0fdc839c22814933fcbd44b1cf5bb-new_light_btn_scenes_fengkuang_dark.png"
+            ],
+            "sceneName": "Crazy",
+            "analyticName": "Crazy",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 807,
+                "scenceName": "",
+                "scenceParam": "AiMAAQAyAAH/gQHoFBQD9RcE/5EA/wCEpwD/L/+QFQP/AACAACMAAQAyAAH/gQHoFBQD9RcE/5EA/wCEpwD/L/+QFwP/AACAAA==",
+                "sceneCode": 2218,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11323,
+                    "scenceParam": "AiMAAQAyAAH/gQHoFBQD9RcE/5EA/wCEpwD/L/+QFQP/AACAACMAAQAyAAH/gQHoFBQD9RcE/5EA/wCEpwD/L/+QFwP/AACAAA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"bright\":[{\"brightValue\":[232,232,255],\"brightPage\":\"0\"}],\"page\":0,\"color\":[245,245,255],\"moveIn\":[252,255,255],\"defaultIndex\":1},{\"moveIn\":[252,255,255],\"defaultIndex\":1,\"bright\":[{\"brightValue\":[232,232,255],\"brightPage\":\"0\"}],\"page\":1,\"color\":[245,245,255]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31323,
+                    "scenceParam": "AiMAAQAyAAH/gQHoFBQD9RcE/5EA/wCEpwD/L/+QFQP/AACAACMAAQAyAAH/gQHoFBQD9RcE/5EA/wCEpwD/L/+QFwP/AACAAA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"bright\": [{\"brightValue\": [232, 242, 255], \"brightPage\": \"0\"}], \"page\": 0, \"color\": [250, 250, 255], \"moveIn\": [252, 255, 255], \"defaultIndex\": 2}, {\"moveIn\": [252, 255, 255], \"defaultIndex\": 2, \"bright\": [{\"brightValue\": [232, 242, 255], \"brightPage\": \"0\"}], \"page\": 1, \"color\": [250, 250, 255]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 750,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/e3997f6345731fed70e6567abfa44829-new_light_btn_scenes_taozui.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/276fa9be893cc876f32562e38e67d281-new_light_btn_scenes_taozui_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/a095560a8438fde44aa476d4cab9c9a8-new_light_btn_scenes_taozui_dark.png"
+            ],
+            "sceneName": "Fascination",
+            "analyticName": "Fascination",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 808,
+                "scenceName": "",
+                "scenceParam": "BSBgAxQAAAH/AACAFBQCABQDAP//AAAAAAAAEQD9AACAASBGAw0BAAH/AACAFBQDABQDAAD/AAAAAP+oEQD+AACAARoAAAABAAH/AACAFBQAgBQBiwD/AACAAACAACYAAQAyAAIvAADDFBT/AADUFBQBABQDiwD/AAAAAP+eFQD+AACAAyYAAQAZAAIoAACsFBT/AAC6FBQBgBQD/wDkAAAAAP//FwD9AACAAw==",
+                "sceneCode": 2219,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11324,
+                    "scenceParam": "BSBgAxQAAAH/AACAFBQCABQDAP//AAAAAAAAEQD9AACAASBGAw0BAAH/AACAFBQDABQDAAD/AAAAAP+oEQD+AACAARoAAAABAAH/AACAFBQAgBQBiwD/AACAAACAACYAAQAyAAIvAADDFBT/AADUFBQBABQDiwD/AAAAAP+eFQD+AACAAyYAAQAZAAIoAACsFBT/AAC6FBQBgBQD/wDkAAAAAP//FwD9AACAAw==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\":[242,249,252],\"page\":0,\"defaultIndex\":1},{\"moveIn\":[244,252,255],\"defaultIndex\":1,\"page\":1},{\"defaultIndex\":1,\"moveIn\":[242,249,252],\"page\":3},{\"moveIn\":[242,249,252],\"defaultIndex\":1,\"page\":4}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31324,
+                    "scenceParam": "BSBgAxQAAAH/AACAFBQCABQDAP//AAAAAAAAEQD9AACAASBGAw0BAAH/AACAFBQDABQDAAD/AAAAAP+oEQD+AACAARoAAAABAAH/AACAFBQAgBQBiwD/AACAAACAACYAAQAyAAIvAADDFBT/AADUFBQBABQDiwD/AAAAAP+eFQD+AACAAyYAAQAZAAIoAACsFBT/AAC6FBQBgBQD/wDkAAAAAP//FwD9AACAAw==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\": [242, 249, 252], \"page\": 0, \"defaultIndex\": 2}, {\"moveIn\": [244, 252, 255], \"defaultIndex\": 2, \"page\": 1}, {\"defaultIndex\": 2, \"moveIn\": [242, 249, 252], \"page\": 3}, {\"moveIn\": [242, 249, 252], \"defaultIndex\": 2, \"page\": 4}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          }
+        ]
+      },
+      {
+        "categoryId": 36,
+        "categoryName": "Dance",
+        "scenes": [
+          {
+            "sceneId": 251,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/a6debb972e67ffa526d7ccc8d51bfc61-new_light_btn_scenes_jixie.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/481426346cc9c3d6195c84ca9896223e-new_light_btn_scenes_jixie_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/b0e53826fdbf2b638b1c4315826993fd-new_light_btn_scenes_jixie_dark.png"
+            ],
+            "sceneName": "Poppin",
+            "analyticName": "Poppin",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 2,
+            "scenesHint": "Siren:Those with epilepsy may experience discomfort when using this Scene mode. Exercise caution during use.",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 248,
+                "scenceName": "A",
+                "scenceParam": "AiMAAhkBAgH/4QCAFBQCABQE//8AAP8AAAAAAAAAFAD/EQD/AB0AAQAIAAEDAgH/FBQAgBQC//8AAP8AFQD/AACAAA==",
+                "sceneCode": 2039,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11325,
+                    "scenceParam": "AiMAAhkBAgH/4QCAFBQCABQE//8AAP8AAAAAAAAAFAD/EQD/AB0AAQAIAAEDAgH/FBQAgBQC//8AAP8AFQD/AACAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\":[247,252,255],\"moveAll\":[247,252,255],\"page\":0,\"defaultIndex\":1},{\"moveIn\":[247,252,255],\"page\":1,\"defaultIndex\":1}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31325,
+                    "scenceParam": "AiMAAhkBAgH/4QCAFBQCABQE//8AAP8AAAAAAAAAFAD/EQD/AB0AAQAIAAEDAgH/FBQAgBQC//8AAP8AFQD/AACAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\": [247, 252, 255], \"moveAll\": [247, 252, 255], \"page\": 0, \"defaultIndex\": 2}, {\"moveIn\": [247, 252, 255], \"page\": 1, \"defaultIndex\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 249,
+                "scenceName": "B",
+                "scenceParam": "ASkAAhQBAAH/AAH//wEA/wUG/wAA//8AAP8AAP//iwD//wbTEwrzAQH4AA==",
+                "sceneCode": 2074,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11326,
+                    "scenceParam": "ASkAAhQBAAH/AAH//wEA/wUG/wAA//8AAP8AAP//iwD//wbTEwrzAQH4AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[244,252,252,252]}],\"page\":0,\"defaultIndex\":1,\"moveIn\":[234,243,249,252],\"color\":[244,252,252,252]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31326,
+                    "scenceParam": "ASkAAhQBAAH/AAH//wEA/wUG/wAA//8AAP8AAP//iwD//wbTEwrzAQH4AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"bright\": [{\"brightPage\": \"0\", \"brightValue\": [244, 252, 252, 252]}], \"page\": 0, \"defaultIndex\": 2, \"moveIn\": [234, 243, 249, 252], \"color\": [244, 252, 252, 252]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 371,
+                "scenceName": "C",
+                "scenceParam": "ATUAAhkEAgP/AAHbYQf/AADTWwb/AADZPQ0C7gMG/xElAAAAAP8AAAAAAAD/AAAAEAXPEgXiAw==",
+                "sceneCode": 2104,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11327,
+                    "scenceParam": "ATUAAhkEAgP/AAHbYQf/AADTWwb/AADZPQ0C7gMG/xElAAAAAP8AAAAAAAD/AAAAEAXPEgXiAw==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\":[207,216,224,224],\"page\":0,\"moveAll\":[226,234,242,244],\"defaultIndex\":0}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31327,
+                    "scenceParam": "ATUAAhkEAgP/AAHbYQf/AADTWwb/AADZPQ0C7gMG/xElAAAAAP8AAAAAAAD/AAAAEAXPEgXiAw==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\": [207, 216, 229, 224], \"page\": 0, \"moveAll\": [226, 234, 242, 244], \"defaultIndex\": 1}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 406,
+                "scenceName": "D",
+                "scenceParam": "BRoAAQABAAH/AACAFBQAgBQBAP//AACAEAD/ABoAAQABAAH/AACAFBQAgBQBzAD/EgD/EgD9ABoAAQABAAH/AACAFBQAgBQB////EwD/EAD7ABoAAQABAAH/AACAFBQAgBQBAP8AEQD/EAD5ACAAAAABAAFNAAG0CgqB/xQDAP+udQD//1kAAACAAACAAA==",
+                "sceneCode": 2135,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11328,
+                    "scenceParam": "BRoAAQABAAH/AACAFBQAgBQBAP//AACAEAD/ABoAAQABAAH/AACAFBQAgBQBzAD/EgD/EgD9ABoAAQABAAH/AACAFBQAgBQB////EwD/EAD7ABoAAQABAAH/AACAFBQAgBQBAP8AEQD/EAD5ACAAAAABAAFNAAG0CgqB/xQDAP+udQD//1kAAACAAACAAA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveAll\":[242,249,252,255],\"defaultIndex\":2,\"page\":0},{\"moveIn\":[242,249,252,252],\"page\":1,\"defaultIndex\":2,\"moveAll\":[242,249,253,252]},{\"moveIn\":[242,249,252,252],\"moveAll\":[239,247,251,252],\"page\":2,\"defaultIndex\":2},{\"moveIn\":[242,249,252,252],\"page\":3,\"defaultIndex\":2,\"moveAll\":[239,247,249,249]},{\"color\":[242,249,252,252],\"defaultIndex\":2,\"page\":4}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31328,
+                    "scenceParam": "BRoAAQABAAH/AACAFBQAgBQBAP//AACAEAD/ABoAAQABAAH/AACAFBQAgBQBzAD/EgD/EgD9ABoAAQABAAH/AACAFBQAgBQB////EwD/EAD7ABoAAQABAAH/AACAFBQAgBQBAP8AEQD/EAD5ACAAAAABAAFNAAG0CgqB/xQDAP+udQD//1kAAACAAACAAA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveAll\": [242, 249, 252, 255], \"defaultIndex\": 3, \"page\": 0}, {\"moveIn\": [242, 249, 252, 252], \"page\": 1, \"defaultIndex\": 3, \"moveAll\": [242, 249, 253, 252]}, {\"moveIn\": [242, 249, 252, 252], \"moveAll\": [239, 247, 251, 252], \"page\": 2, \"defaultIndex\": 3}, {\"moveIn\": [242, 249, 252, 252], \"page\": 3, \"defaultIndex\": 3, \"moveAll\": [239, 247, 249, 249]}, {\"color\": [242, 249, 252, 252], \"defaultIndex\": 3, \"page\": 4}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 409,
+                "scenceName": "E",
+                "scenceParam": "AxoAAyUwAAG5AACAFBQDohQB/wAAEAD+EQD8ARoAAxYuAAFIAACAFBQDgBQBAAD/EAD7EQD+AhoAAQARAAExAACAFBQBgBQBAP//AACAEwD/AA==",
+                "sceneCode": 2138,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11329,
+                    "scenceParam": "AxoAAyUwAAG5AACAFBQDohQB/wAAEAD+EQD8ARoAAxYuAAFIAACAFBQDgBQBAAD/EAD7EQD+AhoAAQARAAExAACAFBQBgBQBAP//AACAEwD/AA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\":0,\"moveAll\":[247,252,255],\"moveIn\":[247,252,252],\"defaultIndex\":1},{\"moveIn\":[247,252,252],\"moveAll\":[247,252,255],\"page\":1,\"defaultIndex\":1},{\"moveAll\":[247,252,255],\"page\":2,\"defaultIndex\":1}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31329,
+                    "scenceParam": "AxoAAyUwAAG5AACAFBQDohQB/wAAEAD+EQD8ARoAAxYuAAFIAACAFBQDgBQBAAD/EAD7EQD+AhoAAQARAAExAACAFBQBgBQBAP//AACAEwD/AA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\": 0, \"moveAll\": [247, 252, 255], \"moveIn\": [247, 252, 252], \"defaultIndex\": 2}, {\"moveIn\": [247, 252, 252], \"moveAll\": [247, 252, 255], \"page\": 1, \"defaultIndex\": 2}, {\"moveAll\": [247, 252, 255], \"page\": 2, \"defaultIndex\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 412,
+                "scenceName": "F",
+                "scenceParam": "AxoAAAABAAFERAAA/wEAgBQBNP/pAACAAACAAR0AAwQEAAH/AACAFBQC9xQCAAD/2gf/EADxAACABR0AAwQEAAEYGACAFBQC9xQCAAD/2gf/EgDxAACABA==",
+                "sceneCode": 2141,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11330,
+                    "scenceParam": "AxoAAAABAAFERAAA/wEAgBQBNP/pAACAAACAAR0AAwQEAAH/AACAFBQC9xQCAAD/2gf/EADxAACABR0AAwQEAAEYGACAFBQC9xQCAAD/2gf/EgDxAACABA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\":[241,249,252],\"page\":1,\"color\":[247,252,252],\"defaultIndex\":0},{\"moveIn\":[241,249,252],\"color\":[247,249,252],\"page\":2,\"defaultIndex\":0}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31330,
+                    "scenceParam": "AxoAAAABAAFERAAA/wEAgBQBNP/pAACAAACAAR0AAwQEAAH/AACAFBQC9xQCAAD/2gf/EADxAACABR0AAwQEAAEYGACAFBQC9xQCAAD/2gf/EgDxAACABA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\": [241, 249, 252], \"page\": 1, \"color\": [252, 255, 255], \"defaultIndex\": 1}, {\"moveIn\": [241, 249, 252], \"color\": [252, 254, 255], \"page\": 2, \"defaultIndex\": 1}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 419,
+                "scenceName": "G",
+                "scenceParam": "AikAAQAyAAH//wCAFBQD5woG/wAA/38A//8AAP8AAAD/AP//EA/mAACAABoAAwEBAAH/mQD0FBQAgBQB////AACAEArzAA==",
+                "sceneCode": 2148,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11331,
+                    "scenceParam": "AikAAQAyAAH//wCAFBQD5woG/wAA/38A//8AAP8AAAD/AP//EA/mAACAABoAAwEBAAH/mQD0FBQAgBQB////AACAEArzAA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":1,\"color\":[231,231,252],\"page\":0,\"moveIn\":[244,252,255]},{\"page\":1,\"moveAll\":[239,247,255],\"defaultIndex\":1}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31331,
+                    "scenceParam": "AikAAQAyAAH//wCAFBQD5woG/wAA/38A//8AAP8AAAD/AP//EA/mAACAABoAAwEBAAH/mQD0FBQAgBQB////AACAEArzAA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\": 2, \"color\": [236, 236, 255], \"page\": 0, \"moveIn\": [244, 252, 255]}, {\"page\": 1, \"moveAll\": [239, 247, 255], \"defaultIndex\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 420,
+                "scenceName": "H",
+                "scenceParam": "AikAAhkZAAH/AACAFBQAgBQG/wAA/0sH//8AAP8AAAD/iwD/EBvOEBvwACMAAhkZAAH/AACAFBQAgBQE/waBB/n/kv8JBlr+EBvVEBvTAA==",
+                "sceneCode": 2149,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 1769,
+                "scenceName": "I",
+                "scenceParam": "BSAAAwIDAAHGAACAFBQA7AkD/wAh/wD+FgD/AACAAACAAiAAAggDAAH/AACAFBQA9gID/wAh/wD+FgD/EQLGAACAACYAAwELAAH/AACAFBQB/wYF////AAAAAAAAAAAAAAAAAACAAACABSMAAgoEAAFNAACAFBQB2RQEAP/3Ff8A/+0A/wYAFADyAACAAiMAAgoEAAFOAACAFBQB2RQEAP/3Ff8A/+0A/wYAFgDyAACAAQ==",
+                "sceneCode": 2287,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11332,
+                    "scenceParam": "BSAAAwIDAAHGAACAFBQA7AkD/wAh/wD+FgD/AACAAACAAiAAAggDAAH/AACAFBQA9gID/wAh/wD+FgD/EQLGAACAACYAAwELAAH/AACAFBQB/wYF////AAAAAAAAAAAAAAAAAACAAACABSMAAgoEAAFNAACAFBQB2RQEAP/3Ff8A/+0A/wYAFADyAACAAiMAAgoEAAFOAACAFBQB2RQEAP/3Ff8A/+0A/wYAFgDyAACAAQ==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"color\":[229,236,252],\"defaultIndex\":1,\"page\":0},{\"color\":[229,246,249],\"defaultIndex\":1,\"page\":1,\"moveIn\":[198,198,252]},{\"defaultIndex\":1,\"page\":2,\"color\":[247,255,255]},{\"page\":3,\"defaultIndex\":1,\"moveIn\":[226,242,252],\"color\":[217,217,242]},{\"moveIn\":[229,242,252],\"page\":4,\"color\":[217,217,234],\"defaultIndex\":1}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31332,
+                    "scenceParam": "BSAAAwIDAAHGAACAFBQA7AkD/wAh/wD+FgD/AACAAACAAiAAAggDAAH/AACAFBQA9gID/wAh/wD+FgD/EQLGAACAACYAAwELAAH/AACAFBQB/wYF////AAAAAAAAAAAAAAAAAACAAACABSMAAgoEAAFNAACAFBQB2RQEAP/3Ff8A/+0A/wYAFADyAACAAiMAAgoEAAFOAACAFBQB2RQEAP/3Ff8A/+0A/wYAFgDyAACAAQ==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"color\": [234, 241, 255], \"defaultIndex\": 2, \"page\": 0}, {\"color\": [234, 251, 254], \"defaultIndex\": 2, \"page\": 1, \"moveIn\": [198, 208, 252]}, {\"defaultIndex\": 2, \"page\": 2, \"color\": [252, 255, 255]}, {\"page\": 3, \"defaultIndex\": 2, \"moveIn\": [226, 252, 252], \"color\": [222, 222, 247]}, {\"moveIn\": [229, 252, 252], \"page\": 4, \"color\": [222, 222, 239], \"defaultIndex\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 252,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/d939896abceb767ac5c7ba9840891730-new_light_btn_scenes_dianliu.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/7f8a3a51eb5d41e5ecf0dd12f250d162-new_light_btn_scenes_dianliu_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/59a14a1d6c1fedbe4e558b4315322e1f-new_light_btn_scenes_dianliu_dark.png"
+            ],
+            "sceneName": "Electro Dance",
+            "analyticName": "Electro Dance",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 250,
+                "scenceName": "A",
+                "scenceParam": "BSAQAAABAAH//wD/FBQB/wED/wAAAP8AAAD/AACAAACAACASAAABAAH//wD/FBQB/wED/y8HAP//iwD/AACAAACAACAUAAABAAH//wD/FBQB/wED/wAAAP8AAAD/AACAAACAACAWAAABAAH//wD/FBQB/wED/y8HAP//iwD/AACAAACAACAYAAABAAH//wD/FBQB/wED/wAAAP8AAAD/AACAAACAAA==",
+                "sceneCode": 2481,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11333,
+                    "scenceParam": "BSAQAAABAAH//wD/FBQB/wED/wAAAP8AAAD/AACAAACAACASAAABAAH//wD/FBQB/wED/y8HAP//iwD/AACAAACAACAUAAABAAH//wD/FBQB/wED/wAAAP8AAAD/AACAAACAACAWAAABAAH//wD/FBQB/wED/y8HAP//iwD/AACAAACAACAYAAABAAH//wD/FBQB/wED/wAAAP8AAAD/AACAAACAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":2,\"color\":[244,249,252],\"page\":0},{\"page\":1,\"defaultIndex\":2,\"color\":[244,249,252]},{\"page\":2,\"color\":[244,249,252],\"defaultIndex\":2},{\"defaultIndex\":2,\"color\":[244,249,252],\"page\":3},{\"color\":[244,249,252],\"page\":4,\"defaultIndex\":2}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31333,
+                    "scenceParam": "BSAQAAABAAH//wD/FBQB/wED/wAAAP8AAAD/AACAAACAACASAAABAAH//wD/FBQB/wED/y8HAP//iwD/AACAAACAACAUAAABAAH//wD/FBQB/wED/wAAAP8AAAD/AACAAACAACAWAAABAAH//wD/FBQB/wED/y8HAP//iwD/AACAAACAACAYAAABAAH//wD/FBQB/wED/wAAAP8AAAD/AACAAACAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\": 3, \"color\": [249, 254, 255], \"page\": 0}, {\"page\": 1, \"defaultIndex\": 3, \"color\": [249, 254, 255]}, {\"page\": 2, \"color\": [249, 254, 255], \"defaultIndex\": 3}, {\"defaultIndex\": 3, \"color\": [249, 254, 255], \"page\": 3}, {\"color\": [249, 254, 255], \"page\": 4, \"defaultIndex\": 3}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 251,
+                "scenceName": "B",
+                "scenceParam": "AiAAAQAyAAH//wCAFBQBfhQD/wAAAP8AAAD/FAD+AAD6ACAAAQAyAAH//wCAFBQBfhQD/wAAAP8AAAD/FgD+AAD6AA==",
+                "sceneCode": 2073,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11334,
+                    "scenceParam": "AiAAAQAyAAH//wCAFBQBfhQD/wAAAP8AAAD/FAD+AAD6ACAAAQAyAAH//wCAFBQBfhQD/wAAAP8AAAD/FgD+AAD6AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\":[242,249,252],\"page\":0,\"defaultIndex\":1},{\"defaultIndex\":1,\"moveIn\":[242,249,252],\"page\":1}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31334,
+                    "scenceParam": "AiAAAQAyAAH//wCAFBQBfhQD/wAAAP8AAAD/FAD+AAD6ACAAAQAyAAH//wCAFBQBfhQD/wAAAP8AAAD/FgD+AAD6AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\": [242, 249, 252], \"page\": 0, \"defaultIndex\": 2}, {\"defaultIndex\": 2, \"moveIn\": [242, 249, 252], \"page\": 1}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 369,
+                "scenceName": "C",
+                "scenceParam": "AyAxAAABAAH/AACaFGQA9xQDAP//AF7/AP/aFAD/EwD9AR03AAABAAH/AACaFGQA9xQCKv8AAP9MFAD/EQD5ASA0AAABAAH/AACaFGQB9xQD6wD/aAD/6AD/FAD/EwD9AQ==",
+                "sceneCode": 2102,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11335,
+                    "scenceParam": "AyAxAAABAAH/AACaFGQA9xQDAP//AF7/AP/aFAD/EwD9AR03AAABAAH/AACaFGQA9xQCKv8AAP9MFAD/EQD5ASA0AAABAAH/AACaFGQB9xQD6wD/aAD/6AD/FAD/EwD9AQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\":0,\"defaultIndex\":2,\"moveAll\":[242,249,253,255]},{\"moveAll\":[237,244,249,252],\"page\":1,\"defaultIndex\":2},{\"defaultIndex\":2,\"page\":2,\"moveAll\":[242,249,253,255]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31335,
+                    "scenceParam": "AyAxAAABAAH/AACaFGQA9xQDAP//AF7/AP/aFAD/EwD9AR03AAABAAH/AACaFGQA9xQCKv8AAP9MFAD/EQD5ASA0AAABAAH/AACaFGQB9xQD6wD/aAD/6AD/FAD/EwD9AQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\": 0, \"defaultIndex\": 3, \"moveAll\": [242, 249, 253, 255]}, {\"moveAll\": [237, 244, 249, 252], \"page\": 1, \"defaultIndex\": 3}, {\"defaultIndex\": 3, \"page\": 2, \"moveAll\": [242, 249, 253, 255]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 370,
+                "scenceName": "D",
+                "scenceParam": "BSlVAQAUAgH/AAD/FBQCAAEG/wAA/38A//8AAP8AAAD/iwD/FgD7EgH7AylQAQAUAgH/AAD/FBQCAAEG/wAA/38A//8AAP8AAAD/iwD/FAD7EAH7AykAAAAGAgH/AAD/FBQC9QEG/wAA/38A//8AAP8AAAD/iwD/FQD+AAHlAikAAgUBAAH/AAD/FBQA/wEG////AAAA////AAAAAP//AAAAAQD9EwH/BRoAAAABAAH//wCAFBQAABQBiwD/AACAAACAAQ==",
+                "sceneCode": 2103,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11336,
+                    "scenceParam": "BSlVAQAUAgH/AAD/FBQCAAEG/wAA/38A//8AAP8AAAD/iwD/FgD7EgH7AylQAQAUAgH/AAD/FBQCAAEG/wAA/38A//8AAP8AAAD/iwD/FAD7EAH7AykAAAAGAgH/AAD/FBQC9QEG/wAA/38A//8AAP8AAAD/iwD/FQD+AAHlAikAAgUBAAH/AAD/FBQA/wEG////AAAA////AAAAAP//AAAAAQD9EwH/BRoAAAABAAH//wCAFBQAABQBiwD/AACAAACAAQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveAll\":[242,249,252],\"defaultIndex\":1,\"bright\":[{\"brightValue\":[244,249,249],\"brightPage\":\"0\"}],\"page\":0,\"moveIn\":[242,249,252]},{\"moveIn\":[242,249,252],\"moveAll\":[242,249,252],\"bright\":[{\"brightValue\":[244,249,249],\"brightPage\":\"0\"}],\"defaultIndex\":1,\"page\":1},{\"moveIn\":[242,249,252],\"defaultIndex\":1,\"color\":[242,245,245],\"page\":2},{\"moveAll\":[249,252,255],\"defaultIndex\":1,\"page\":3,\"color\":[249,252,252]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31336,
+                    "scenceParam": "BSlVAQAUAgH/AAD/FBQCAAEG/wAA/38A//8AAP8AAAD/iwD/FgD7EgH7AylQAQAUAgH/AAD/FBQCAAEG/wAA/38A//8AAP8AAAD/iwD/FAD7EAH7AykAAAAGAgH/AAD/FBQC9QEG/wAA/38A//8AAP8AAAD/iwD/FQD+AAHlAikAAgUBAAH/AAD/FBQA/wEG////AAAA////AAAAAP//AAAAAQD9EwH/BRoAAAABAAH//wCAFBQAABQBiwD/AACAAACAAQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveAll\": [242, 249, 252], \"defaultIndex\": 2, \"bright\": [{\"brightValue\": [244, 249, 249], \"brightPage\": \"0\"}], \"page\": 0, \"moveIn\": [242, 249, 252]}, {\"moveIn\": [242, 249, 252], \"moveAll\": [242, 249, 252], \"bright\": [{\"brightValue\": [244, 249, 249], \"brightPage\": \"0\"}], \"defaultIndex\": 2, \"page\": 1}, {\"moveIn\": [242, 249, 252], \"defaultIndex\": 2, \"color\": [247, 250, 250], \"page\": 2}, {\"moveAll\": [249, 252, 255], \"defaultIndex\": 2, \"page\": 3, \"color\": [254, 255, 255]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 424,
+                "scenceName": "E",
+                "scenceParam": "Ax0wAAABAAH/AAB/FBQA1w4C/wAb/wCMEAD/EgD/ASA3AAABAAH/AAB/FBQA2A4DkQD/4AD/+QD/EAD/EgD/ASBDAAABAAH/AAB/FBQA1wsD/wCD/wDc3AD/EAD/EgD/Ag==",
+                "sceneCode": 2153,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11337,
+                    "scenceParam": "Ax0wAAABAAH/AAB/FBQA1w4C/wAb/wCMEAD/EgD/ASA3AAABAAH/AAB/FBQA2A4DkQD/4AD/+QD/EAD/EgD/ASBDAAABAAH/AAB/FBQA1wsD/wCD/wDc3AD/EAD/EgD/Ag==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveAll\":[249,252,255],\"moveIn\":[249,252,255],\"page\":0,\"defaultIndex\":1},{\"moveAll\":[249,252,255],\"moveIn\":[249,252,255],\"page\":1,\"defaultIndex\":1},{\"defaultIndex\":1,\"moveIn\":[249,252,255],\"moveAll\":[249,252,255],\"page\":2}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31337,
+                    "scenceParam": "Ax0wAAABAAH/AAB/FBQA1w4C/wAb/wCMEAD/EgD/ASA3AAABAAH/AAB/FBQA2A4DkQD/4AD/+QD/EAD/EgD/ASBDAAABAAH/AAB/FBQA1wsD/wCD/wDc3AD/EAD/EgD/Ag==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveAll\": [249, 252, 255], \"moveIn\": [249, 252, 255], \"page\": 0, \"defaultIndex\": 2}, {\"moveAll\": [249, 252, 255], \"moveIn\": [249, 252, 255], \"page\": 1, \"defaultIndex\": 2}, {\"defaultIndex\": 2, \"moveIn\": [249, 252, 255], \"moveAll\": [249, 252, 255], \"page\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 379,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/554d533650a66200c376fcaf19db1ca0-new_light_btn_scenes_tange.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/dc36b19d562b523d8787ea9e0a170efb-new_light_btn_scenes_tange_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/e3e30f9a254fd3a92e4b549b7e9d171f-new_light_btn_scenes_tange_dark.png"
+            ],
+            "sceneName": "Tango",
+            "analyticName": "Tango",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 397,
+                "scenceName": "",
+                "scenceParam": "AiAAAQAyAAGRkQCAFBQBgBQDAP//AAD//wAAFwH1AwH/ACMAAQAyAAGRkQCAFBQBgBQEAAAA/38A9/+M/wAAFAH1AQDpAA==",
+                "sceneCode": 2130,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11338,
+                    "scenceParam": "AiAAAQAyAAGRkQCAFBQBgBQDAP//AAD//wAAFwH1AwH/ACMAAQAyAAGRkQCAFBQBgBQEAAAA/38A9/+M/wAAFAH1AQDpAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\":[237,245,249,252],\"page\":0,\"defaultIndex\":1},{\"moveIn\":[237,245,249,252],\"defaultIndex\":1,\"page\":1}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31338,
+                    "scenceParam": "AiAAAQAyAAGRkQCAFBQBgBQDAP//AAD//wAAFwH1AwH/ACMAAQAyAAGRkQCAFBQBgBQEAAAA/38A9/+M/wAAFAH1AQDpAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\": [237, 245, 249, 252], \"page\": 0, \"defaultIndex\": 2}, {\"moveIn\": [237, 245, 249, 252], \"defaultIndex\": 2, \"page\": 1}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 380,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/a01dcccf6288581edbbf673796797d3c-new_light_btn_scenes_qiaqia.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/38b06f5ac9698d56b86961c10b3e8350-new_light_btn_scenes_qiaqia_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/a94bd61e37e5cd0016f0ec07dbfd009b-new_light_btn_scenes_qiaqia_dark.png"
+            ],
+            "sceneName": "Cha-Cha",
+            "analyticName": "Cha-Cha",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 398,
+                "scenceName": "A",
+                "scenceParam": "Ax1QAAABAAH/+wL///8A/WQCAAD//1QHAACAEAD6BR1VAAABAAH/8AD///8A8lYC/wAAB/9eAACAEgD9BSAAAAABAAF/fwD///8A8xQDAAD//wAAAP8AAACAEgD9AA==",
+                "sceneCode": 2131,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11339,
+                    "scenceParam": "Ax1QAAABAAH/+wL///8A/WQCAAD//1QHAACAEAD6BR1VAAABAAH/8AD///8A8lYC/wAAB/9eAACAEgD9BSAAAAABAAF/fwD///8A8xQDAAD//wAAAP8AAACAEgD9AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":1,\"page\":0,\"moveAll\":[242,250,252,255]},{\"page\":1,\"defaultIndex\":1,\"moveAll\":[244,253,255,255]},{\"defaultIndex\":1,\"moveAll\":[244,253,255,255],\"page\":2}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31339,
+                    "scenceParam": "Ax1QAAABAAH/+wL///8A/WQCAAD//1QHAACAEAD6BR1VAAABAAH/8AD///8A8lYC/wAAB/9eAACAEgD9BSAAAAABAAF/fwD///8A8xQDAAD//wAAAP8AAACAEgD9AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\": 2, \"page\": 0, \"moveAll\": [242, 250, 252, 255]}, {\"page\": 1, \"defaultIndex\": 2, \"moveAll\": [244, 253, 255, 255]}, {\"defaultIndex\": 2, \"moveAll\": [244, 253, 255, 255], \"page\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 411,
+                "scenceName": "B",
+                "scenceParam": "ASYAAwEBAAH/AACAFBQBgBQF/wAA/wf0CQ7/CP78CP8KAACAEAP1AA==",
+                "sceneCode": 2140,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11340,
+                    "scenceParam": "ASYAAwEBAAH/AAAAFBQBgBQF/wAA/wf0CQ7/CP78CP8KAACAEAH5AA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveAll\":[237,244,249,252],\"page\":0,\"defaultIndex\":0}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31340,
+                    "scenceParam": "ASYAAwEBAAH/AAAAFBQBgBQF/wAA/wf0CQ7/CP78CP8KAACAEAH5AA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveAll\": [237, 244, 249, 252], \"page\": 0, \"defaultIndex\": 1}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 381,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/500156e7c5e873537e4243351a55adad-new_light_btn_scenes_huaerzi.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/21a793eb756e518b1806772314c31426-new_light_btn_scenes_huaerzi_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/67459b287159a0e830a621f9bbd96b4e-new_light_btn_scenes_huaerzi_dark.png"
+            ],
+            "sceneName": "Waltz",
+            "analyticName": "Waltz",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 405,
+                "scenceName": "A",
+                "scenceParam": "AiAAAQAyAAH/AACAFBQD9AED/wAA//8AAAD/AACAAACAACMAAwEBAAH/AACAFBQA/xQEAP+a/3b7ALD/////EQDoAACAAg==",
+                "sceneCode": 2134,
+                "specialEffect": [],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 423,
+                "scenceName": "B",
+                "scenceParam": "Ah1wAAABAAH/AAGAFBQA2wEC/wAA/38AAACAAACAAB03AAABAAH/AAGBFBQA2gEC/38A/wAAAACAAACAAA==",
+                "sceneCode": 2152,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 382,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/63fcbe2b9da67c34e0b56e241a19c941-new_light_btn_scenes_balei.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/1ea5886a365fe549906f64494f8ff410-new_light_btn_scenes_balei_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/ce3c01630d2769082678a1b1188dd5f7-new_light_btn_scenes_balei_dark.png"
+            ],
+            "sceneName": "Ballet",
+            "analyticName": "Ballet",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 408,
+                "scenceName": "A",
+                "scenceParam": "AiAAAAAGAAH/AACAFBQCywED/0nLi07+/Qb/AACAAACAAB2BAwoFAAH/AAPXZGQBzxQCiwD/LAf+AACAAACAAQ==",
+                "sceneCode": 2137,
+                "specialEffect": [],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 422,
+                "scenceName": "B",
+                "scenceParam": "BCAwAAAGAAH//wB/FBQC8RQD+5j/uDf/Kv/tEgD4AwL4AiA3AAAGAAH//wB/FBQC8RQD+5j/uDf/Kv/tEgD4AwL4AiAlAAAEAAH//wB/FBQC8RQD+5j/uDf/Kv/tEgD4AwL4AiAjAAAEAAH//wB/FBQC8RQD+5j/uDf/Kv/tEgD4AwL4Ag==",
+                "sceneCode": 2151,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11341,
+                    "scenceParam": "BCAwAAAGAAH//wB/FBQC8RQD+5j/uDf/Kv/tEgD4AwL4AiA3AAAGAAH//wB/FBQC8RQD+5j/uDf/Kv/tEgD4AwL4AiAlAAAEAAH//wB/FBQC8RQD+5j/uDf/Kv/tEgD4AwL4AiAjAAAEAAH//wB/FBQC8RQD+5j/uDf/Kv/tEgD4AwL4Ag==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"color\":[229,241,241],\"moveIn\":[239,248,252],\"page\":0,\"defaultIndex\":1},{\"page\":1,\"moveIn\":[239,248,252],\"defaultIndex\":1,\"color\":[229,241,241]},{\"page\":2,\"color\":[229,241,241],\"moveIn\":[239,248,252],\"defaultIndex\":1},{\"color\":[229,241,241],\"moveIn\":[239,248,252],\"page\":3,\"defaultIndex\":1}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31341,
+                    "scenceParam": "BCAwAAAGAAH//wB/FBQC8RQD+5j/uDf/Kv/tEgD4AwL4AiA3AAAGAAH//wB/FBQC8RQD+5j/uDf/Kv/tEgD4AwL4AiAlAAAEAAH//wB/FBQC8RQD+5j/uDf/Kv/tEgD4AwL4AiAjAAAEAAH//wB/FBQC8RQD+5j/uDf/Kv/tEgD4AwL4Ag==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"color\": [234, 246, 246], \"moveIn\": [239, 248, 252], \"page\": 0, \"defaultIndex\": 2}, {\"page\": 1, \"moveIn\": [239, 248, 252], \"defaultIndex\": 2, \"color\": [234, 246, 246]}, {\"page\": 2, \"color\": [234, 246, 246], \"moveIn\": [239, 248, 252], \"defaultIndex\": 2}, {\"color\": [234, 246, 246], \"moveIn\": [239, 248, 252], \"page\": 3, \"defaultIndex\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 383,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/ac0c8e8f42f097428d753bcaa1c44be2-new_light_btn_scenes_piliwu.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/4cd66699b5bdc16edd7f8e6f1bb845ef-new_light_btn_scenes_piliwu_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/f8bf11b216e538c763bde9e6a9716469-new_light_btn_scenes_piliwu_dark.png"
+            ],
+            "sceneName": "Breaking",
+            "analyticName": "Breaking",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 410,
+                "scenceName": "A",
+                "scenceParam": "Ax1QAw0XAAFHAACAFBQDgBQCAP//iwD/EAD9EQD9ACBVAw4XAAFJAACAFBQDgBQDAAD/AAAA/wAAEwD+EwD+ACYAAwowAAEiAACAFBQBgBQFAP8AAAAAAAAAAAj/AAAAFAD9EAD3AQ==",
+                "sceneCode": 2139,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11342,
+                    "scenceParam": "Ax1QAw0XAAFHAACAFBQDgBQCAP//iwD/EAD9EQD9ACBVAw4XAAFJAACAFBQDgBQDAAD/AAAA/wAAEwD+EwD+ACYAAwowAAEiAACAFBQBgBQFAP8AAAAAAAAAAAj/AAAAFAD9EAD3AQ==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":1,\"page\":0,\"moveAll\":[244,253,255],\"moveIn\":[244,253,255]},{\"moveIn\":[252,254,254],\"moveAll\":[252,254,254],\"defaultIndex\":1,\"page\":1},{\"moveAll\":[239,247,252],\"defaultIndex\":1,\"moveIn\":[244,253,255],\"page\":2}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31342,
+                    "scenceParam": "Ax1QAw0XAAFHAACAFBQDgBQCAP//iwD/EAD9EQD9ACBVAw4XAAFJAACAFBQDgBQDAAD/AAAA/wAAEwD+EwD+ACYAAwowAAEiAACAFBQBgBQFAP8AAAAAAAAAAAj/AAAAFAD9EAD3AQ==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\": 2, \"page\": 0, \"moveAll\": [244, 253, 255], \"moveIn\": [244, 253, 255]}, {\"moveIn\": [252, 254, 254], \"moveAll\": [252, 254, 254], \"defaultIndex\": 2, \"page\": 1}, {\"moveAll\": [239, 247, 252], \"defaultIndex\": 2, \"moveIn\": [244, 253, 255], \"page\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 426,
+                "scenceName": "B",
+                "scenceParam": "AykAAwEBAAEnAACAFBQBgBQGAP//AAAA/wAAAAAAAAAAAAAAFQD9AACAACkAAwEBAAElAACAFBQBgBQGAAD/AAAAAP8AAAAAAAAAAAAAFwD9AACAAiYAAxQBAAEhAACAFBQBgBQF/wDpAAAAAAAAAAAAAAAAFwD+AACAAw==",
+                "sceneCode": 2155,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11343,
+                    "scenceParam": "AykAAwEBAAEnAACAFBQBgBQGAP//AAAA/wAAAAAAAAAAAAAAFQD9AACAACkAAwEBAAElAACAFBQBgBQGAAD/AAAAAP8AAAAAAAAAAAAAFwD9AACAAiYAAxQBAAEhAACAFBQBgBQF/wDpAAAAAAAAAAAAAAAAFwD+AACAAw==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":1,\"moveIn\":[242,249,252],\"page\":0},{\"defaultIndex\":1,\"moveIn\":[242,249,252],\"page\":1},{\"defaultIndex\":1,\"moveIn\":[244,252,255],\"page\":2}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31343,
+                    "scenceParam": "AykAAwEBAAEnAACAFBQBgBQGAP//AAAA/wAAAAAAAAAAAAAAFQD9AACAACkAAwEBAAElAACAFBQBgBQGAAD/AAAAAP8AAAAAAAAAAAAAFwD9AACAAiYAAxQBAAEhAACAFBQBgBQF/wDpAAAAAAAAAAAAAAAAFwD+AACAAw==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\": 2, \"moveIn\": [242, 249, 252], \"page\": 0}, {\"defaultIndex\": 2, \"moveIn\": [242, 249, 252], \"page\": 1}, {\"defaultIndex\": 2, \"moveIn\": [244, 252, 255], \"page\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 384,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/2e19b609b9f8f6245c77023df9ce5e5c-new_light_btn_scenes_lading.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/aa6308e7430ef7657c9a8c8b994d220b-new_light_btn_scenes_lading_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/01aa7fa59103123d7e20f204d55f500c-new_light_btn_scenes_lading_dark.png"
+            ],
+            "sceneName": "Latin Dance",
+            "analyticName": "Latin Dance",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 413,
+                "scenceName": "",
+                "scenceParam": "AykAAQAyAAH/gQHoFBQDABQGiwD//wCJ3wD/7CX//7T1////FwL/AwL/ACkAAQAyAAH/gQHoFBQDABQGiwD//wCJ3wD/7CX//7T1////FQL/AwL/AB0AAwEEAAH/AACAFBQDpgMC/////wAAFQD/AAH/AA==",
+                "sceneCode": 2142,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11344,
+                    "scenceParam": "AykAAQAyAAH/gQHoFBQDABQGiwD//wCJ3wD/7CX//7T1////FwL/AwL/ACkAAQAyAAH/gQHoFBQDABQGiwD//wCJ3wD/7CX//7T1////FQL/AwL/AB0AAwEEAAH/AACAFBQDpgMC/////wAAFQD/AAH/AA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\":[242,249,252,255],\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[224,224,232,232]}],\"defaultIndex\":2,\"page\":0},{\"defaultIndex\":2,\"page\":1,\"bright\":[{\"brightValue\":[224,224,232,232],\"brightPage\":\"0\"}],\"moveIn\":[242,249,252,255]},{\"page\":2,\"defaultIndex\":2,\"moveIn\":[242,249,252,255]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31344,
+                    "scenceParam": "AykAAQAyAAH/gQHoFBQDABQGiwD//wCJ3wD/7CX//7T1////FwL/AwL/ACkAAQAyAAH/gQHoFBQDABQGiwD//wCJ3wD/7CX//7T1////FQL/AwL/AB0AAwEEAAH/AACAFBQDpgMC/////wAAFQD/AAH/AA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\": [242, 249, 252, 255], \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [224, 224, 237, 232]}], \"defaultIndex\": 3, \"page\": 0}, {\"defaultIndex\": 3, \"page\": 1, \"bright\": [{\"brightValue\": [224, 224, 237, 232], \"brightPage\": \"0\"}], \"moveIn\": [242, 249, 252, 255]}, {\"page\": 2, \"defaultIndex\": 3, \"moveIn\": [242, 249, 252, 255]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 386,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/985461c9b9157f5d9f60ec63fd94bdbf-new_light_btn_scenes_jueshiwu.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/b3c03739ab3b3ac49ad7c78de09cd3c0-new_light_btn_scenes_jueshiwu_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/8818c2a6f1c49996e87d6255123bfefd-new_light_btn_scenes_jueshiwu_dark.png"
+            ],
+            "sceneName": "Jazz",
+            "analyticName": "Jazz",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 415,
+                "scenceName": "A",
+                "scenceParam": "AiAAAAAKAAH//wD3FBQCABQD/wAA/38AiwD/AAB/AAB/AyMAAAAKAAH//wB/FBQC+hQE/wAA/38AiwD/AP/+AAB/EwD/Aw==",
+                "sceneCode": 2144,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11345,
+                    "scenceParam": "AiAAAAAKAAH//wD3FBQCABQD/wAA/38AiwD/AAB/AAB/AyMAAAAKAAH//wB/FBQC+hQE/wAA/38AiwD/AP/+AAB/EwD/Aw==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":2,\"moveAll\":[242,249,252],\"page\":1}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31345,
+                    "scenceParam": "AiAAAAAKAAH//wD3FBQCABQD/wAA/38AiwD/AAB/AAB/AyMAAAAKAAH//wB/FBQC+hQE/wAA/38AiwD/AP/+AAB/EwD/Aw==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":2,\"moveAll\":[242,249,252],\"page\":1}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 1762,
+                "scenceName": "B",
+                "scenceParam": "BSAAAQAeAAHMzAAABAMBAB4D/wAAAAAAAAAAFwD+AgKPASAAAQAeAAHMzAAABAMBABQD/38AAAAAAAAAFQD+AgLIASlQAAABAAH//wD/AQGA/zwGAAAAAAAAAAD/AAAA/wAAAP8AFwD+AwDdAilVAAABAAH//wD/AQEA/zwGAAD/AAAAAAAAAP8A/wAAAAD/FQD+AwDdAilVAAABAAEAAAD/AQEA/zwGAAAAAAAAAAAAiwD//wz9AAAAEwD+AwDdAg==",
+                "sceneCode": 2282,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11346,
+                    "scenceParam": "BSAAAQAeAAHMzAAABAMBAB4D/wAAAAAAAAAAFwD+AgKPASAAAQAeAAHMzAAABAMBABQD/38AAAAAAAAAFQD+AgLIASlQAAABAAH//wD/AQGA/zwGAAAAAAAAAAD/AAAA/wAAAP8AFwD+AwDdAilVAAABAAH//wD/AQEA/zwGAAD/AAAAAAAAAP8A/wAAAAD/FQD+AwDdAilVAAABAAEAAAD/AQEA/zwGAAAAAAAAAAAAiwD//wz9AAAAEwD+AwDdAg==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\":0,\"defaultIndex\":1,\"moveIn\":[249,252,252]},{\"page\":1,\"moveIn\":[249,252,252],\"defaultIndex\":1},{\"moveIn\":[249,252,255],\"page\":2,\"defaultIndex\":1},{\"moveIn\":[249,252,255],\"page\":3,\"defaultIndex\":1},{\"defaultIndex\":1,\"moveIn\":[252,254,254],\"page\":4}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31346,
+                    "scenceParam": "BSAAAQAeAAHMzAAABAMBAB4D/wAAAAAAAAAAFwD+AgKPASAAAQAeAAHMzAAABAMBABQD/38AAAAAAAAAFQD+AgLIASlQAAABAAH//wD/AQGA/zwGAAAAAAAAAAD/AAAA/wAAAP8AFwD+AwDdAilVAAABAAH//wD/AQEA/zwGAAD/AAAAAAAAAP8A/wAAAAD/FQD+AwDdAilVAAABAAEAAAD/AQEA/zwGAAAAAAAAAAAAiwD//wz9AAAAEwD+AwDdAg==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\": 0, \"defaultIndex\": 2, \"moveIn\": [249, 252, 252]}, {\"page\": 1, \"moveIn\": [249, 252, 252], \"defaultIndex\": 2}, {\"moveIn\": [249, 252, 255], \"page\": 2, \"defaultIndex\": 2}, {\"moveIn\": [249, 252, 255], \"page\": 3, \"defaultIndex\": 2}, {\"defaultIndex\": 2, \"moveIn\": [252, 254, 254], \"page\": 4}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 387,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/9178d22d279f0ef2a2d2fce87f6a9288-new_light_btn_scenes_gangguanwu.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/3370495e0cfbe98a586518e2439b78a9-new_light_btn_scenes_gangguanwu_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/7168393f8365a59b298b2ff92eb61711-new_light_btn_scenes_gangguanwu_dark.png"
+            ],
+            "sceneName": "Pole dance",
+            "analyticName": "Pole dance",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 416,
+                "scenceName": "A",
+                "scenceParam": "BSAzAAAGAAH/AAB/FBQA+y0DAP/x/wDZAAAAEAD8EgD/ASAjAAABAAH/AAB/FBQA/C0D/wDqAP/8AAAAEgD+EgD/AiA0AAAGAAH/AAB/FBQA/C0DAP/x/wDZAAAAEgD8EAD/ASAoAAABAAH/AAB/FBQA+y0D/wDZAP/yAAAAEAD9EAD/AhooAAABAAH/iQGtHRQAfxQB////AAB/EQD/AQ==",
+                "sceneCode": 2145,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11347,
+                    "scenceParam": "BSAzAAAGAAH/AAB/FBQA+y0DAP/x/wDZAAAAEAD8EgD/ASAjAAABAAH/AAB/FBQA/C0D/wDqAP/8AAAAEgD+EgD/AiA0AAAGAAH/AAB/FBQA/C0DAP/x/wDZAAAAEgD8EAD/ASAoAAABAAH/AAB/FBQA+y0D/wDZAP/yAAAAEAD9EAD/AhooAAABAAH/iQGtHRQAfxQB////AAB/EQD/AQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\":0,\"moveIn\":[244,252,252],\"moveAll\":[244,252,252],\"defaultIndex\":1},{\"moveAll\":[244,252,255],\"page\":1,\"moveIn\":[244,252,255],\"defaultIndex\":1},{\"moveIn\":[244,252,252],\"page\":2,\"defaultIndex\":1,\"moveAll\":[244,252,252]},{\"moveAll\":[244,252,255],\"moveIn\":[244,253,255],\"defaultIndex\":1,\"page\":3},{\"page\":4,\"defaultIndex\":1,\"moveAll\":[244,252,252]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31347,
+                    "scenceParam": "BSAzAAAGAAH/AAB/FBQA+y0DAP/x/wDZAAAAEAD8EgD/ASAjAAABAAH/AAB/FBQA/C0D/wDqAP/8AAAAEgD+EgD/AiA0AAAGAAH/AAB/FBQA/C0DAP/x/wDZAAAAEgD8EAD/ASAoAAABAAH/AAB/FBQA+y0D/wDZAP/yAAAAEAD9EAD/AhooAAABAAH/iQGtHRQAfxQB////AAB/EQD/AQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\": 0, \"moveIn\": [244, 252, 252], \"moveAll\": [244, 252, 252], \"defaultIndex\": 2}, {\"moveAll\": [244, 252, 255], \"page\": 1, \"moveIn\": [244, 252, 255], \"defaultIndex\": 2}, {\"moveIn\": [244, 252, 252], \"page\": 2, \"defaultIndex\": 2, \"moveAll\": [244, 252, 252]}, {\"moveAll\": [244, 252, 255], \"moveIn\": [244, 253, 255], \"defaultIndex\": 2, \"page\": 3}, {\"page\": 4, \"defaultIndex\": 2, \"moveAll\": [244, 252, 252]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 1772,
+                "scenceName": "B",
+                "scenceParam": "BSZiAAASAgH/AAC2BQUBzxQFAAAAF2j/AAAA/wAAAAAAFQH7AACAACZCAAASAgH/AAC2BQUBShQFAAAAAAAAAAAADP8AAAAAFQH7AACAACZiAAAMAgH/AAC2BQUBShQFAAAA/wD+AAAAAAAAAAAAFQH7AACAACZEAAAMAgH/AAC2BQUBShQFAAAAAAAAAAAAAAAA/f8AFQH7AACAACliAwEBAgH/AAC2BQWBShQGAAAA////AAAAAAAA/Pv/AAAAFQD7AACAAA==",
+                "sceneCode": 2290,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11348,
+                    "scenceParam": "BSZiAAASAgH/AAC2BQUBzxQFAAAAF2j/AAAA/wAAAAAAFQH7AACAACZCAAASAgH/AAC2BQUBShQFAAAAAAAAAAAADP8AAAAAFQH7AACAACZiAAAMAgH/AAC2BQUBShQFAAAA/wD+AAAAAAAAAAAAFQH7AACAACZEAAAMAgH/AAC2BQUBShQFAAAAAAAAAAAAAAAA/f8AFQH7AACAACliAwEBAgH/AAC2BQWBShQGAAAA////AAAAAAAA/Pv/AAAAFQD7AACAAA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":1,\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[182,182,206]}],\"moveIn\":[242,251,255],\"color\":[207,207,229],\"page\":0},{\"defaultIndex\":1,\"bright\":[{\"brightValue\":[182,182,201],\"brightPage\":\"0\"}],\"moveIn\":[242,251,255],\"page\":1},{\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[182,182,214]}],\"moveIn\":[242,251,255],\"page\":2,\"defaultIndex\":1},{\"page\":3,\"defaultIndex\":1,\"moveIn\":[242,251,255],\"bright\":[{\"brightValue\":[182,182,216],\"brightPage\":\"0\"}]},{\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[182,182,209]}],\"page\":4,\"defaultIndex\":1,\"moveIn\":[242,251,255]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31348,
+                    "scenceParam": "BSZiAAASAgH/AAC2BQUBzxQFAAAAF2j/AAAA/wAAAAAAFQH7AACAACZCAAASAgH/AAC2BQUBShQFAAAAAAAAAAAADP8AAAAAFQH7AACAACZiAAAMAgH/AAC2BQUBShQFAAAA/wD+AAAAAAAAAAAAFQH7AACAACZEAAAMAgH/AAC2BQUBShQFAAAAAAAAAAAAAAAA/f8AFQH7AACAACliAwEBAgH/AAC2BQWBShQGAAAA////AAAAAAAA/Pv/AAAAFQD7AACAAA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\": 2, \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [182, 192, 206]}], \"moveIn\": [242, 251, 255], \"color\": [212, 212, 234], \"page\": 0}, {\"defaultIndex\": 2, \"bright\": [{\"brightValue\": [182, 192, 201], \"brightPage\": \"0\"}], \"moveIn\": [242, 251, 255], \"page\": 1}, {\"bright\": [{\"brightPage\": \"0\", \"brightValue\": [182, 192, 214]}], \"moveIn\": [242, 251, 255], \"page\": 2, \"defaultIndex\": 2}, {\"page\": 3, \"defaultIndex\": 2, \"moveIn\": [242, 251, 255], \"bright\": [{\"brightValue\": [182, 192, 216], \"brightPage\": \"0\"}]}, {\"bright\": [{\"brightPage\": \"0\", \"brightValue\": [182, 192, 209]}], \"page\": 4, \"defaultIndex\": 2, \"moveIn\": [242, 251, 255]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 388,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/0f61b43d0a74aeafbf02c106f7c61f5a-new_light_btn_scenes_jiewu.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/39e4d7cdf9d3490ce582785b56129c4c-new_light_btn_scenes_jiewu_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/5b9af6ca99e0d2f7eb0b086931c1f99d-new_light_btn_scenes_jiewu_dark.png"
+            ],
+            "sceneName": "Street Dance",
+            "analyticName": "Street Dance",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 417,
+                "scenceName": "A",
+                "scenceParam": "ASkAAAABAAH//wD/FBSD/x4G/wAA/38A//8AAP8AAAD/AP//FwH/EQH/AA==",
+                "sceneCode": 2146,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11349,
+                    "scenceParam": "ASkAAAABAAH//wD/FBSD/x4G/wAA/38A//8AAP8AAAD/AP//FwH/EQH/AA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\":[242,249,252,255],\"page\":0,\"moveAll\":[242,249,252,255],\"defaultIndex\":2}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31349,
+                    "scenceParam": "ASkAAAABAAH//wD/FBSD/x4G/wAA/38A//8AAP8AAAD/AP//FwH/EQH/AA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\": [242, 249, 252, 255], \"page\": 0, \"moveAll\": [242, 249, 252, 255], \"defaultIndex\": 3}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 2878,
+                "scenceName": "B",
+                "scenceParam": "AilQAAABAAH//wD/FBQA/wEG/wAA/38A//8AAP8AAAD/iwD/FAH9AACAAClVAAABAAH//wD/FBQA/wEGiwD/AAD/AP8A//8A/38A/wAAFAH9AACAAA==",
+                "sceneCode": 2495,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11350,
+                    "scenceParam": "AilQAAABAAH//wD/FBQA/wEG/wAA/38A//8AAP8AAAD/iwD/FAH9AACAAClVAAABAAH//wD/FBQA/wEGiwD/AAD/AP8A//8A/38A/wAAFAH9AACAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"color\":[242,249,252,252],\"page\":0,\"moveIn\":[242,249,253,255],\"defaultIndex\":2},{\"moveIn\":[242,249,253,255],\"color\":[242,249,252,252],\"page\":1,\"defaultIndex\":2}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31350,
+                    "scenceParam": "AilQAAABAAH//wD/FBQA/wEG/wAA/38A//8AAP8AAAD/iwD/FAH9AACAAClVAAABAAH//wD/FBQA/wEGiwD/AAD/AP8A//8A/38A/wAAFAH9AACAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"color\": [242, 249, 252, 252], \"page\": 0, \"moveIn\": [242, 249, 253, 255], \"defaultIndex\": 3}, {\"moveIn\": [242, 249, 253, 255], \"color\": [242, 249, 252, 252], \"page\": 1, \"defaultIndex\": 3}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          }
+        ]
+      },
+      {
+        "categoryId": 64,
+        "categoryName": "Movie",
+        "scenes": [
+          {
+            "sceneId": 365,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/ee0de9d249e30885ded9e718bbfafcf8-new_light_btn_scenes_xiju.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/704f4b4c1f08e5674125ae55dbbdf720-new_light_btn_scenes_xiju_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/ab00b57ba6bb1e59bbd781e9329f052c-new_light_btn_scenes_xiju_dark.png"
+            ],
+            "sceneName": "Comedies",
+            "analyticName": "Comedies",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 376,
+                "scenceName": "",
+                "scenceParam": "AikAAQAyAAH//wAAFBQBgBQG/wAA/38A//8AAP8AAAD/iwD/AACAEAD4ABoAAAAyAgElAAPzFBQAgBQB////AACAAACAAA==",
+                "sceneCode": 2109,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11351,
+                    "scenceParam": "AikAAQAyAAH//wAAFBQBgBQG/wAA/38A//8AAP8AAAD/iwD/AACAEAD4ABoAAAAyAgElAAPzFBQAgBQB////AACAAACAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":1,\"moveAll\":[239,248,252],\"page\":0}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31351,
+                    "scenceParam": "AikAAQAyAAH//wAAFBQBgBQG/wAA/38A//8AAP8AAAD/iwD/AACAEAD4ABoAAAAyAgElAAPzFBQAgBQB////AACAAACAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\": 2, \"moveAll\": [239, 248, 252], \"page\": 0}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 366,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/d6e96f091392bf637fa43d5c8296241d-new_light_btn_scenes_huaju.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/10704828693c883b08ce0707c9bffd40-new_light_btn_scenes_huaju_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/68702fb7dc84057f12eba0227943ecf8-new_light_btn_scenes_huaju_dark.png"
+            ],
+            "sceneName": "Dramas",
+            "analyticName": "Dramas",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 377,
+                "scenceName": "",
+                "scenceParam": "BR0wAQAPAAH/AAAB//8BABQCAAD//wAAEAD6AAB/BB1DAQAUAAH/AAABFBQBABQCAP///wD4EAD7AAB/AR03AQAPAAH/AAABFBQBABQCAP/i/wAAEAD4AAB/BB1QAAABAAH/AADz//8C+BQCAP//AQD/AAB/AAB/BR1VAAABAAH/AAD1//8C+xQC/wAAiwD/AAB/AAB/BQ==",
+                "sceneCode": 2110,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 367,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/bd1392313df9ade35af70cbfe7fc9910-new_light_btn_scenes_kongbupian.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/58e640031bc24c3a9f2f9bf66c1e3fff-new_light_btn_scenes_kongbupian_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/8c696048709a4198dbf93b6077c26e3d-new_light_btn_scenes_kongbupian_dark.png"
+            ],
+            "sceneName": "Thrillers",
+            "analyticName": "Thrillers",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 2,
+            "scenesHint": "Those with epilepsy may experience discomfort when using this Scene mode. Exercise caution during use.",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 378,
+                "scenceName": "",
+                "scenceParam": "AiZDAQABAAH/AAPkFBQA/xQF/xFO/xIA/54JAAAA////EAT/EAPjBSMVAAABAAL/AADYFBT/AAHSCg8C/xQCDwz/IwD/EAMXEAPWBQ==",
+                "sceneCode": 2111,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11352,
+                    "scenceParam": "AiZDAQABAAH/AAPkFBQA/xQF/xFO/xIA/54JAAAA////EAT/EAPjBSMVAAABAAL/AADYFBT/AAHSCg8C/xQCDwz/IwD/EAMXEAPWBQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"color\":[242,252,252],\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[204,228,242]}],\"moveIn\":[226,244,252],\"moveAll\":[216,227,252],\"page\":0,\"defaultIndex\":1},{\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[204,216,226]},{\"brightPage\":\"1\",\"brightValue\":[204,210,226]}],\"page\":1,\"moveAll\":[209,214,249],\"defaultIndex\":1}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31352,
+                    "scenceParam": "AiZDAQABAAH/AAPkFBQA/xQF/xFO/xIA/54JAAAA////EAT/EAPjBSMVAAABAAL/AADYFBT/AAHSCg8C/xQCDwz/IwD/EAMXEAPWBQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"color\": [247, 255, 255], \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [204, 238, 242]}], \"moveIn\": [226, 254, 252], \"moveAll\": [216, 237, 252], \"page\": 0, \"defaultIndex\": 2}, {\"bright\": [{\"brightPage\": \"0\", \"brightValue\": [204, 226, 226]}, {\"brightPage\": \"1\", \"brightValue\": [204, 220, 226]}], \"page\": 1, \"moveAll\": [209, 224, 249], \"defaultIndex\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 368,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/0d52c562cceb1b4910afe2d931db210e-new_light_btn_scenes_aiqingpian.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/5b3b05d64f641966075608b4e3a81bea-new_light_btn_scenes_aiqingpian_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/6f1b2b8465f7d98b4770d09d86d8a04b-new_light_btn_scenes_aiqingpian_dark.png"
+            ],
+            "sceneName": "Romance",
+            "analyticName": "Romance",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 379,
+                "scenceName": "A",
+                "scenceParam": "AxpQAAAZAAH/AAB/FBQCfxQBAP//AAB/AAB/ARpkAAABAAH/AAABFBQCABQB/wD6AAB/AAB/ASMAAQAsAAH/AAABFBQBABQEAAAAAAAAAAAAAP//AAB/EAD7BQ==",
+                "sceneCode": 2112,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11353,
+                    "scenceParam": "AxpQAAAZAAH/AAB/FBQCfxQBAP//AAB/AAB/ARpkAAABAAH/AAABFBQCABQB/wD6AAB/AAB/ASMAAQAsAAH/AAABFBQBABQEAAAAAAAAAAAAAP//AAB/EAD7BQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveAll\":[229,242,251],\"page\":2,\"defaultIndex\":2}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31353,
+                    "scenceParam": "AxpQAAAZAAH/AAB/FBQCfxQBAP//AAB/AAB/ARpkAAABAAH/AAABFBQCABQB/wD6AAB/AAB/ASMAAQAsAAH/AAABFBQBABQEAAAAAAAAAAAAAP//AAB/EAD7BQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveAll\": [229, 252, 251], \"page\": 2, \"defaultIndex\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 380,
+                "scenceName": "B",
+                "scenceParam": "AikAAAABAAH/AAABFBQA+hQGAAD/AAAA/wDsAAAAAP//AAAABACEAAB/BSkAAQAyAAH/AAABFBQBABQGAAD/AAAAAP//AAAA8AD/AAAAEAD2AAB/AQ==",
+                "sceneCode": 2113,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 369,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/878dd7b7cff0101063a8e11973e1682d-new_light_btn_scenes_jilupian.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/75117475c1e90de775201bed267e90d4-new_light_btn_scenes_jilupian_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/219ff31266965c4f6568aba0caddf3aa-new_light_btn_scenes_jilupian_dark.png"
+            ],
+            "sceneName": "Documentaries",
+            "analyticName": "Documentaries",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 381,
+                "scenceName": "",
+                "scenceParam": "AyMAAAAEAAG7SgHGFAECgBQEmf8JVv52AP8AKv4rAACAAACAASAAAQADAAH//wCAFBQBwxQDAAD/NXr/EDz+EADbAACABSAAAQADAAH//wCAFBQBwxQDAAD/NXr/EDz+EgDbAACABQ==",
+                "sceneCode": 2114,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 370,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/3b54f60804c1c8bb7cb61df8499d3ff0-new_light_btn_scenes_kehuanpian.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/46834319f54bd216b59b4dbff29d06c8-new_light_btn_scenes_kehuanpian_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/086a2213736a737f0431046e47515e00-new_light_btn_scenes_kehuanpian_dark.png"
+            ],
+            "sceneName": "Science Fiction",
+            "analyticName": "Science Fiction",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 382,
+                "scenceName": "A",
+                "scenceParam": "BSkiAQABAAH//wCAFBQB/30G/wAA/38A//8AAP8AAAD/iwD/EwD5AACAACkkAQABAAH//wCAFBQB/30G/wAA/38A//8AAP8AAAD/iwD/EQD5AACAACkmAQABAAH//wCAFBQB/30G/wAA/38A//8AAP8AAAD/iwD/EwD5AACAACkoAQABAAH//wCAFBQB/30G/wAA/38A//8AAP8AAAD/iwD/EQD5AACAACkgAQABAAH//wCAFBQB/30G/wAA/38A//8AAP8AAAD/iwD/EQD5AACAAA==",
+                "sceneCode": 2115,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11354,
+                    "scenceParam": "BSkiAQABAAH//wCAFBQB/30G/wAA/38A//8AAP8AAAD/iwD/EwD5AACAACkkAQABAAH//wCAFBQB/30G/wAA/38A//8AAP8AAAD/iwD/EQD5AACAACkmAQABAAH//wCAFBQB/30G/wAA/38A//8AAP8AAAD/iwD/EwD5AACAACkoAQABAAH//wCAFBQB/30G/wAA/38A//8AAP8AAAD/iwD/EQD5AACAACkgAQABAAH//wCAFBQB/30G/wAA/38A//8AAP8AAAD/iwD/EQD5AACAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":1,\"moveIn\":[237,249,252],\"page\":0,\"color\":[252,255,255]},{\"moveIn\":[237,249,252],\"defaultIndex\":1,\"color\":[252,255,255],\"page\":1},{\"defaultIndex\":1,\"page\":2,\"moveIn\":[237,249,252],\"color\":[252,255,255]},{\"page\":3,\"moveIn\":[237,249,252],\"color\":[252,255,255],\"defaultIndex\":1},{\"color\":[252,255,255],\"defaultIndex\":1,\"page\":4,\"moveIn\":[237,249,252]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31354,
+                    "scenceParam": "BSkiAQABAAH//wCAFBQB/30G/wAA/38A//8AAP8AAAD/iwD/EwD5AACAACkkAQABAAH//wCAFBQB/30G/wAA/38A//8AAP8AAAD/iwD/EQD5AACAACkmAQABAAH//wCAFBQB/30G/wAA/38A//8AAP8AAAD/iwD/EwD5AACAACkoAQABAAH//wCAFBQB/30G/wAA/38A//8AAP8AAAD/iwD/EQD5AACAACkgAQABAAH//wCAFBQB/30G/wAA/38A//8AAP8AAAD/iwD/EQD5AACAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\": 2, \"moveIn\": [237, 249, 252], \"page\": 0, \"color\": [255, 255, 255]}, {\"moveIn\": [237, 249, 252], \"defaultIndex\": 2, \"color\": [255, 255, 255], \"page\": 1}, {\"defaultIndex\": 2, \"page\": 2, \"moveIn\": [237, 249, 252], \"color\": [255, 255, 255]}, {\"page\": 3, \"moveIn\": [237, 249, 252], \"color\": [255, 255, 255], \"defaultIndex\": 2}, {\"color\": [255, 255, 255], \"defaultIndex\": 2, \"page\": 4, \"moveIn\": [237, 249, 252]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 383,
+                "scenceName": "B",
+                "scenceParam": "AxoAAAABAAH/AAB/FBQAfxQBAP//AAB/AAB/ASkAAQAyAAH/AADvFBQBABQGAAD/AAAAAAAAAAD/AAAAAAAAAAB/AAB/BSNVAQAZAAH/AAD8FBQAABQEAAAAAAAAAAAAAP//AAB/AAB/BQ==",
+                "sceneCode": 2116,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 371,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/abec376a5ca9b5dc358adff206e1d8ce-new_light_btn_scenes_xuanyipian.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/5df672471d64695d77b6fd7770de0040-new_light_btn_scenes_xuanyipian_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/1591c693ab15ec849118b3231631c246-new_light_btn_scenes_xuanyipian_dark.png"
+            ],
+            "sceneName": "Suspence",
+            "analyticName": "Suspence",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 384,
+                "scenceName": "",
+                "scenceParam": "Ax0AAQAyAAH/AADs//8CABQCAP///wAAAAB/AAB/BR1QAQAZAAH/AAABFBQBABQCAP8AAAD/EAD2AAB/AR1VAQAZAAH/AAABFBQBABQCAAD//gD/EAD0AAB/Ag==",
+                "sceneCode": 2117,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 372,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/a8628f3d697268d08a145e42c5d55233-new_light_btn_scenes_zhanzhengpian.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/498a4cce248866e4bebf11664ccca4cf-new_light_btn_scenes_zhanzhengpian_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/18dcaba2999c14974a61e83f17b3c55d-new_light_btn_scenes_zhanzhengpian_dark.png"
+            ],
+            "sceneName": "War Films",
+            "analyticName": "War Films",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 385,
+                "scenceName": "A",
+                "scenceParam": "BBoAAAABAAENDQCAFBQAAAEBB/8lAACAAACAAR0AAhkUAAH/bgDbASgA/hQC/+kH/xMHAACAAACABR0xAAAJAAH/AAD/AWQCgBQC////AAAAAACAAACAAh02AAAJAAH/AAL/AWQCgBQC////AAAAAACAAACAAg==",
+                "sceneCode": 2118,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11355,
+                    "scenceParam": "BBoAAAABAAENDQCAFBQAAAEBB/8lAACAAACAAR0AAhkUAAH/bgDbASgA/hQC/+kH/xMHAACAAACABR0xAAAJAAH/AAD/AWQCgBQC////AAAAAACAAACAAh02AAAJAAH/AAL/AWQCgBQC////AAAAAACAAACAAg==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\":1,\"color\":[242,252,254],\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[201,204,219]}],\"defaultIndex\":2},{\"defaultIndex\":2,\"page\":2,\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[216,229,244]}]},{\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[216,229,244]}],\"page\":3,\"defaultIndex\":2}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31355,
+                    "scenceParam": "BBoAAAABAAENDQCAFBQAAAEBB/8lAACAAACAAR0AAhkUAAH/bgDbASgA/hQC/+kH/xMHAACAAACABR0xAAAJAAH/AAD/AWQCgBQC////AAAAAACAAACAAh02AAAJAAH/AAL/AWQCgBQC////AAAAAACAAACAAg==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\": 1, \"color\": [247, 255, 255], \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [201, 214, 219]}], \"defaultIndex\": 2}, {\"defaultIndex\": 2, \"page\": 2, \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [216, 239, 244]}]}, {\"bright\": [{\"brightPage\": \"0\", \"brightValue\": [216, 239, 244]}], \"page\": 3, \"defaultIndex\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 386,
+                "scenceName": "B",
+                "scenceParam": "BClQAQAZAAH/AAABFBQBABQGAAD/AAAAAAAA/wAAAAAAAAAAFwD9AAB/ASlVAAAZAAH/AAABFBQBABQGAP//AAAAAAAA//8AAAAAAAAAFQD9AAB/ARpQAAABAAH/AAD///8AABQBAAD/AAB/AAB/BRpVAAABAAH/AAD///8AABQBAP//AAB/AAB/BQ==",
+                "sceneCode": 2119,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 373,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/53eb40f47d1e6b1dec1fb8e574456e26-new_light_btn_scenes_dongzuopian.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/35a1ca99e877c1b9ac40a4d37017b7be-new_light_btn_scenes_dongzuopian_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/3836e0ff6c3564e3b7d35e40418d9db6-new_light_btn_scenes_dongzuopian_dark.png"
+            ],
+            "sceneName": "Action",
+            "analyticName": "Action",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 387,
+                "scenceName": "A",
+                "scenceParam": "AxoAAAABAgF/GgH0KBQAgBQB+ADfAACAAACAABoAAgQBAgH/fwPmAQEAgBQB////AQD8AACAABoAAAAZAgFLAAP7OP8AgBQBAAD/AACAEQD/AA==",
+                "sceneCode": 2120,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11356,
+                    "scenceParam": "AxoAAAABAgF/GgH0KBQAgBQB+ADfAACAAACAABoAAgQBAgH/fwPmAQEAgBQB////AQD8AACAABoAAAAZAgFLAAP7OP8AgBQBAAD/AACAEQD/AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"bright\":[{\"brightValue\":[204,216,230],\"brightPage\":\"0\"}],\"defaultIndex\":2,\"page\":1},{\"moveAll\":[244,252,255],\"page\":2,\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[237,244,251]}],\"defaultIndex\":2}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31356,
+                    "scenceParam": "AxoAAAABAgF/GgH0KBQAgBQB+ADfAACAAACAABoAAgQBAgH/fwPmAQEAgBQB////AQD8AACAABoAAAAZAgFLAAP7OP8AgBQBAAD/AACAEQD/AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"bright\": [{\"brightValue\": [204, 226, 230], \"brightPage\": \"0\"}], \"defaultIndex\": 2, \"page\": 1}, {\"moveAll\": [244, 252, 255], \"page\": 2, \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [237, 254, 251]}], \"defaultIndex\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 388,
+                "scenceName": "B",
+                "scenceParam": "BR0AAQAJAAH/AAD/lpYBABQCAAD///8AEADsAACABB0AAAABAAENAAAA/wEA/5YCCQj+/wsHAACAAACAAB0AAQAJAAH/AAL/lpYBABQC/wAAAP8AEADsAACABB0AAQAJAAH/AAL/lpYBABQC/wAAAP8AEgDsAACABR0AAQAJAAH/AAD/lpYBABQCAAD///8AEgDsAACABQ==",
+                "sceneCode": 2121,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11357,
+                    "scenceParam": "BR0AAQAJAAH/AAD/lpYBABQCAAD///8AEADsAACABB0AAAABAAENAAAA/wEA/5YCCQj+/wsHAACAAACAAB0AAQAJAAH/AAL/lpYBABQC/wAAAP8AEADsAACABB0AAQAJAAH/AAL/lpYBABQC/wAAAP8AEgDsAACABR0AAQAJAAH/AAD/lpYBABQCAAD///8AEgDsAACABQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\":[236,244,252,255],\"defaultIndex\":0,\"page\":0},{\"page\":2,\"defaultIndex\":0,\"moveIn\":[236,244,252,255]},{\"page\":3,\"defaultIndex\":0,\"moveIn\":[236,244,252,255]},{\"moveIn\":[236,244,252,255],\"page\":4,\"defaultIndex\":0}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31357,
+                    "scenceParam": "BR0AAQAJAAH/AAD/lpYBABQCAAD///8AEADsAACABB0AAAABAAENAAAA/wEA/5YCCQj+/wsHAACAAACAAB0AAQAJAAH/AAL/lpYBABQC/wAAAP8AEADsAACABB0AAQAJAAH/AAL/lpYBABQC/wAAAP8AEgDsAACABR0AAQAJAAH/AAD/lpYBABQCAAD///8AEgDsAACABQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\": [236, 244, 252, 255], \"defaultIndex\": 1, \"page\": 0}, {\"page\": 2, \"defaultIndex\": 1, \"moveIn\": [236, 244, 252, 255]}, {\"page\": 3, \"defaultIndex\": 1, \"moveIn\": [236, 244, 252, 255]}, {\"moveIn\": [236, 244, 252, 255], \"page\": 4, \"defaultIndex\": 1}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 389,
+                "scenceName": "C",
+                "scenceParam": "BR0QAQABAAH//wB/FBQA/wQC/wAHAAP/AAB/EAD/ARoTAQABAAH//wB/FBQBfxQB/wAEAAB/EAD/ARoZAQABAAH//wB/FBQBsAoB/8UAAAB/EgD/AR0ZAQACAAH//wB/FBQBAAEC/38A/38AAAB/EgD6ARogAQACAAH/AAB/FBQAfxQB/1MAAAB/EQD2AQ==",
+                "sceneCode": 2122,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11358,
+                    "scenceParam": "BR0QAQABAAH//wB/FBQA/wQC/wAHAAP/AAB/EAD/ARoTAQABAAH//wB/FBQBfxQB/wAEAAB/EAD/ARoZAQABAAH//wB/FBQBsAoB/8UAAAB/EgD/AR0ZAQACAAH//wB/FBQBAAEC/38A/38AAAB/EgD6ARogAQACAAH/AAB/FBQAfxQB/1MAAAB/EQD2AQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"color\":[252,255,255,255],\"defaultIndex\":2,\"moveAll\":[237,244,252,255],\"page\":0},{\"defaultIndex\":2,\"page\":1,\"moveAll\":[237,244,252,255]},{\"page\":2,\"moveAll\":[237,244,252,255],\"defaultIndex\":2},{\"moveAll\":[234,242,250,252],\"defaultIndex\":2,\"page\":3},{\"moveAll\":[229,237,246,252],\"defaultIndex\":2,\"page\":4}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31358,
+                    "scenceParam": "BR0QAQABAAH//wB/FBQA/wQC/wAHAAP/AAB/EAD/ARoTAQABAAH//wB/FBQBfxQB/wAEAAB/EAD/ARoZAQABAAH//wB/FBQBsAoB/8UAAAB/EgD/AR0ZAQACAAH//wB/FBQBAAEC/38A/38AAAB/EgD6ARogAQACAAH/AAB/FBQAfxQB/1MAAAB/EQD2AQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"color\": [252, 255, 255, 255], \"defaultIndex\": 3, \"moveAll\": [237, 244, 252, 255], \"page\": 0}, {\"defaultIndex\": 3, \"page\": 1, \"moveAll\": [237, 244, 252, 255]}, {\"page\": 2, \"moveAll\": [237, 244, 252, 255], \"defaultIndex\": 3}, {\"moveAll\": [234, 242, 250, 252], \"defaultIndex\": 3, \"page\": 3}, {\"moveAll\": [229, 237, 246, 252], \"defaultIndex\": 3, \"page\": 4}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 801,
+                "scenceName": "D",
+                "scenceParam": "BR1AAgIBAAH//wD/FBQA/xQCiwD/AP8AEQH/AACAAB1GAgIBAAH//wD/FBQA/xQCAP8AiwD/EwH/AACAAB0QAAABAAH//wAAFBQA/xQCAP8AiwD/AACAEQD/AR0ZAAABAAH//wAAFBQA/xQCiwD/AP8ABwH/EwD/AR0kAgoBAAH//wCAFBQA/xQCiwD/AP8AEQH/AACAAA==",
+                "sceneCode": 2212,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11359,
+                    "scenceParam": "BR1AAgIBAAH//wD/FBQA/xQCiwD/AP8AEQH/AACAAB1GAgIBAAH//wD/FBQA/xQCAP8AiwD/EwH/AACAAB0QAAABAAH//wAAFBQA/xQCAP8AiwD/AACAEQD/AR0ZAAABAAH//wAAFBQA/xQCiwD/AP8ABwH/EwD/AR0kAgoBAAH//wCAFBQA/xQCiwD/AP8AEQH/AACAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\":0,\"color\":[247,252,255,255],\"defaultIndex\":2,\"moveIn\":[234,242,249,252]},{\"page\":1,\"color\":[247,252,255,255],\"moveIn\":[237,244,252,255],\"defaultIndex\":2},{\"color\":[244,252,255,255],\"moveAll\":[237,244,252,255],\"defaultIndex\":2,\"page\":2},{\"page\":3,\"defaultIndex\":2,\"color\":[244,252,255,255],\"moveAll\":[237,244,252,255]},{\"defaultIndex\":2,\"color\":[244,252,255,255],\"page\":4,\"moveIn\":[234,242,249,252]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31359,
+                    "scenceParam": "BR1AAgIBAAH//wD/FBQA/xQCiwD/AP8AEQH/AACAAB1GAgIBAAH//wD/FBQA/xQCAP8AiwD/EwH/AACAAB0QAAABAAH//wAAFBQA/xQCAP8AiwD/AACAEQD/AR0ZAAABAAH//wAAFBQA/xQCiwD/AP8ABwH/EwD/AR0kAgoBAAH//wCAFBQA/xQCiwD/AP8AEQH/AACAAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\": 0, \"color\": [247, 252, 255, 255], \"defaultIndex\": 3, \"moveIn\": [234, 242, 249, 252]}, {\"page\": 1, \"color\": [247, 252, 255, 255], \"moveIn\": [237, 244, 252, 255], \"defaultIndex\": 3}, {\"color\": [244, 252, 255, 255], \"moveAll\": [237, 244, 252, 255], \"defaultIndex\": 3, \"page\": 2}, {\"page\": 3, \"defaultIndex\": 3, \"color\": [244, 252, 255, 255], \"moveAll\": [237, 244, 252, 255]}, {\"defaultIndex\": 3, \"color\": [244, 252, 255, 255], \"page\": 4, \"moveIn\": [234, 242, 249, 252]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          }
+        ]
+      },
+      {
+        "categoryId": 66,
+        "categoryName": "Music",
+        "scenes": [
+          {
+            "sceneId": 374,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/8301fe192ea53b95184cb8b99fe37d78-new_light_btn_scenes_gaokang.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/5371323208c479931e0b04bdaee11536-new_light_btn_scenes_gaokang_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/384d869433ce36720a8ef9de14c6aaf8-new_light_btn_scenes_gaokang_dark.png"
+            ],
+            "sceneName": "High",
+            "analyticName": "High",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 390,
+                "scenceName": "",
+                "scenceParam": "AhpAAgoFAAH/vwH/WkYB41AB/wAAFQD/EAD/ARpCAhQKAAH/sAP/FBQB/2QBABT/EQD/EwD/BQ==",
+                "sceneCode": 2123,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11375,
+                    "scenceParam": "AhpAAgoFAAH/vwH/WkYB41AB/wAAFQD/EAD/ARpCAhQKAAH/sAP/FBQB/2QBABT/EQD/EwD/BQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveAll\":[239,247,252,255],\"page\":0,\"moveIn\":[239,247,252,252],\"defaultIndex\":2},{\"defaultIndex\":2,\"moveIn\":[239,247,252,252],\"moveAll\":[239,247,252,255],\"page\":1}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31375,
+                    "scenceParam": "AhpAAgoFAAH/vwH/WkYB41AB/wAAFQD/EAD/ARpCAhQKAAH/sAP/FBQB/2QBABT/EQD/EwD/BQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveAll\": [239, 247, 252, 255], \"page\": 0, \"moveIn\": [239, 247, 252, 252], \"defaultIndex\": 3}, {\"defaultIndex\": 3, \"moveIn\": [239, 247, 252, 252], \"moveAll\": [239, 247, 252, 255], \"page\": 1}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 375,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/img/a7239b01bb1a5de6c98189304b7d0eb7-new_light_btn_scenes_dance_wave%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/7ed0b9678d23ec4a1cd6f3225726ee60-new_light_btn_scenes_dance_wave_press%403x.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/img/59d79dfe5229b8147cd446d1566b9302-new_light_btn_scenes_dance_wave_dark%403x.png"
+            ],
+            "sceneName": "Dancing",
+            "analyticName": "Dancing",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 391,
+                "scenceName": "A",
+                "scenceParam": "Ax0AAAABAAH/AAB/UhQAzQMCAwD/ZwD/EAN/EAN/ARooAAABAAH/AACpZBQAoAEB/wDdEAHLEAD/ARogAAABAAH/AAB/FBQAfwEBAP/aEgF/EgD/Ag==",
+                "sceneCode": 2124,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11376,
+                    "scenceParam": "Ax0AAAABAAH/AAB/UhQAzQMCAwD/ZwD/EAN/EAN/ARooAAABAAH/AACpZBQAoAEB/wDdEAHLEAD/ARogAAABAAH/AAB/FBQAfwEBAP/aEgF/EgD/Ag==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\":1,\"moveIn\":[203,203,203,252],\"defaultIndex\":2,\"moveAll\":[239,247,252,255]},{\"moveAll\":[239,247,252,255],\"moveIn\":[127,127,127,252],\"defaultIndex\":2,\"page\":2}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31376,
+                    "scenceParam": "Ax0AAAABAAH/AAB/UhQAzQMCAwD/ZwD/EAN/EAN/ARooAAABAAH/AACpZBQAoAEB/wDdEAHLEAD/ARogAAABAAH/AAB/FBQAfwEBAP/aEgF/EgD/Ag==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\": 1, \"moveIn\": [203, 203, 208, 252], \"defaultIndex\": 3, \"moveAll\": [239, 247, 252, 255]}, {\"moveAll\": [239, 247, 252, 255], \"moveIn\": [127, 127, 132, 252], \"defaultIndex\": 3, \"page\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 716,
+                "scenceName": "B",
+                "scenceParam": "BSkAAQAyAAH/AAD/ZMgCAAEGiwD/AAD/AP8A//8A/38A/wAAFAD/AACABSkAAQAyAAH/AAD/ZMgCAAEGiwD/AAD/AP8A//8A/38A/wAAFgD/AACABSkAAQAyAAH/AAL/ZMgCAAEG/wAA/38A//8AAP8AAAD/iwD/FAD/AACABCkAAQAyAAH/AAL/ZMgCAAEG/wAA/38A//8AAP8AAAD/iwD/FgD/AACABCkAAhkUAgH//wP/ZMgCWwEG/wAA/38A//8AAP8AAAD/iwD/EQH0AACAAQ==",
+                "sceneCode": 2209,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11377,
+                    "scenceParam": "BSkAAQAyAAH/AAD/ZMgCAAEGiwD/AAD/AP8A//8A/38A/wAAFAD/AACABSkAAQAyAAH/AAD/ZMgCAAEGiwD/AAD/AP8A//8A/38A/wAAFgD/AACABSkAAQAyAAH/AAL/ZMgCAAEG/wAA/38A//8AAP8AAAD/iwD/FAD/AACABCkAAQAyAAH/AAL/ZMgCAAEG/wAA/38A//8AAP8AAAD/iwD/FgD/AACABCkAAhkUAgH//wP/ZMgCWwEG/wAA/38A//8AAP8AAAD/iwD/EQH0AACAAQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\":0,\"moveIn\":[239,247,252,255],\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[242,249,249,249]}],\"defaultIndex\":2},{\"moveIn\":[239,247,252,255],\"page\":1,\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[242,249,249,249]}],\"defaultIndex\":2},{\"defaultIndex\":2,\"page\":2,\"moveIn\":[239,247,252,255],\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[242,249,249,249]}]},{\"defaultIndex\":2,\"bright\":[{\"brightValue\":[242,249,249,249],\"brightPage\":\"0\"}],\"page\":3,\"moveIn\":[239,247,252,255]},{\"page\":4,\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[237,249,249,249]}],\"defaultIndex\":2,\"moveIn\":[229,237,244,252]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31377,
+                    "scenceParam": "BSkAAQAyAAH/AAD/ZMgCAAEGiwD/AAD/AP8A//8A/38A/wAAFAD/AACABSkAAQAyAAH/AAD/ZMgCAAEGiwD/AAD/AP8A//8A/38A/wAAFgD/AACABSkAAQAyAAH/AAL/ZMgCAAEG/wAA/38A//8AAP8AAAD/iwD/FAD/AACABCkAAQAyAAH/AAL/ZMgCAAEG/wAA/38A//8AAP8AAAD/iwD/FgD/AACABCkAAhkUAgH//wP/ZMgCWwEG/wAA/38A//8AAP8AAAD/iwD/EQH0AACAAQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\": 0, \"moveIn\": [239, 247, 252, 255], \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [242, 249, 249, 249]}], \"defaultIndex\": 3}, {\"moveIn\": [239, 247, 252, 255], \"page\": 1, \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [242, 249, 249, 249]}], \"defaultIndex\": 3}, {\"defaultIndex\": 3, \"page\": 2, \"moveIn\": [239, 247, 252, 255], \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [242, 249, 249, 249]}]}, {\"defaultIndex\": 3, \"bright\": [{\"brightValue\": [242, 249, 249, 249], \"brightPage\": \"0\"}], \"page\": 3, \"moveIn\": [239, 247, 252, 255]}, {\"page\": 4, \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [237, 249, 249, 249]}], \"defaultIndex\": 3, \"moveIn\": [229, 237, 244, 252]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 2879,
+                "scenceName": "C",
+                "scenceParam": "AxozAg8PAAE0IwL//2aA//8B////FgD/Ah3/BSZDAhQMAAH//wH/Af+D//8FAAAA////AAAA////iwD/FBL4EhT6BSYAAwEwAAL/AALiExX/AADoFBSDqwwDJSX/fwj+/QDdEAAAEQD+AA==",
+                "sceneCode": 2496,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11378,
+                    "scenceParam": "AxozAg8PAAE0IwL//2aA//8B////FgD/Ah3/BSZDAhQMAAH//wH/Af+D//8FAAAA////AAAA////iwD/FBL4EhT6BSYAAwEwAAL/AALiExX/AADoFBSDqwwDJSX/fwj+/QDdEAAAEQD+AA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[247,252,252]}],\"page\":0,\"defaultIndex\":1,\"moveIn\":[239,252,255]},{\"color\":[239,247,247],\"page\":1,\"moveIn\":[232,247,252],\"moveAll\":[229,244,252],\"defaultIndex\":1},{\"page\":2,\"bright\":[{\"brightValue\":[224,232,232],\"brightPage\":\"1\"},{\"brightPage\":\"0\",\"brightValue\":[219,226,226]}],\"defaultIndex\":1,\"moveAll\":[237,252,255]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31378,
+                    "scenceParam": "AxozAg8PAAE0IwL//2aA//8B////FgD/Ah3/BSZDAhQMAAH//wH/Af+D//8FAAAA////AAAA////iwD/FBL4EhT6BSYAAwEwAAL/AALiExX/AADoFBSDqwwDJSX/fwj+/QDdEAAAEQD+AA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"bright\": [{\"brightPage\": \"0\", \"brightValue\": [247, 252, 252]}], \"page\": 0, \"defaultIndex\": 2, \"moveIn\": [239, 252, 255]}, {\"color\": [244, 252, 252], \"page\": 1, \"moveIn\": [232, 247, 252], \"moveAll\": [229, 254, 252], \"defaultIndex\": 2}, {\"page\": 2, \"bright\": [{\"brightValue\": [224, 242, 232], \"brightPage\": \"1\"}, {\"brightPage\": \"0\", \"brightValue\": [219, 236, 226]}], \"defaultIndex\": 2, \"moveAll\": [237, 252, 255]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 747,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/4e483ca6cf835a68a8bc677b22167df9-new_light_btn_scenes_shuhuan.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/f0512cb3c767c591f5495c70a667a4c4-new_light_btn_scenes_shuhuan_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/acb1ea1dd99c8fce2749179683c6b583-new_light_btn_scenes_shuhuan_dark.png"
+            ],
+            "sceneName": "Soothing",
+            "analyticName": "Soothing",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 803,
+                "scenceName": "A",
+                "scenceParam": "AiAAAwYAAgGaDAOaMjKAThQDAP//YML+TN/+EgGBAACAACAAAhkBAgHKZQMeMjIAThQDAP//YML+TN/+EgExAACAAA==",
+                "sceneCode": 2214,
+                "specialEffect": [],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 1765,
+                "scenceName": "B",
+                "scenceParam": "ASMAAwYAAgE2DAMA/2QDPhQEQK/+OW3/Spr/e7T+AgPwEAD8AA==",
+                "sceneCode": 2283,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11379,
+                    "scenceParam": "ASMAAwYAAgE2DAMA/2QDPhQEQK/+OW3/Spr/e7T+AgPwEAD8AA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":2,\"moveAll\":[239,247,252],\"page\":0}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31379,
+                    "scenceParam": "ASMAAwYAAgE2DAMA/2QDPhQEQK/+OW3/Spr/e7T+AgPwEAD8AA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":2,\"moveAll\":[239,247,252],\"page\":0}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          }
+        ]
+      },
+      {
+        "categoryId": 68,
+        "categoryName": "Games",
+        "scenes": [
+          {
+            "sceneId": 394,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/26bc46ac084fb47ae10b1732fcbb9a11-new_light_btn_scenes_sheji.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/a04a0d8c653791b65d6bb6b42b62d32a-new_light_btn_scenes_sheji_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/4fbfad844f42c75737feac641e04d41a-new_light_btn_scenes_sheji_dark.png"
+            ],
+            "sceneName": "Shooting Game",
+            "analyticName": "Shooting Game",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 431,
+                "scenceName": "A",
+                "scenceParam": "BB0gAQADAAH/AAP/AwMByhQC/24A/+QAAAB/AAB/ASARAQADAAH/AAB/FBQBfxQD/6wCAAAA//8AAAB/EAP8ASARAQADAAH/AAB/FBQBfxQD/+lJAAAA/44AAAB/EAT8ASAZAQADAAH/AADqAgQA0RQD/wAD/wAA/wAAAAB/AAB/AQ==",
+                "sceneCode": 2160,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11360,
+                    "scenceParam": "BB0gAQADAAH/AAP/AwMByhQC/24A/+QAAAB/AAB/ASARAQADAAH/AAB/FBQBfxQD/6wCAAAA//8AAAB/EAP8ASARAQADAAH/AAB/FBQBfxQD/+lJAAAA/44AAAB/EAT8ASAZAQADAAH/AADqAgQA0RQD/wAD/wAA/wAAAAB/AAB/AQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"bright\":[{\"brightValue\":[216,229,249,252,252],\"brightPage\":\"0\"}],\"page\":0,\"defaultIndex\":3},{\"defaultIndex\":3,\"page\":1,\"moveAll\":[234,242,242,249,252]},{\"moveAll\":[234,242,242,249,252],\"defaultIndex\":3,\"page\":2},{\"page\":3,\"defaultIndex\":3,\"bright\":[{\"brightValue\":[209,216,216,224,242],\"brightPage\":\"0\"}]},{\"defaultIndex\":3,\"page\":4,\"bright\":[{\"brightValue\":[229,229,249,252,252],\"brightPage\":\"0\"}]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31360,
+                    "scenceParam": "BB0gAQADAAH/AAP/AwMByhQC/24A/+QAAAB/AAB/ASARAQADAAH/AAB/FBQBfxQD/6wCAAAA//8AAAB/EAP8ASARAQADAAH/AAB/FBQBfxQD/+lJAAAA/44AAAB/EAT8ASAZAQADAAH/AADqAgQA0RQD/wAD/wAA/wAAAAB/AAB/AQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"bright\": [{\"brightValue\": [216, 229, 252, 252], \"brightPage\": \"0\"}], \"page\": 0, \"defaultIndex\": 3}, {\"defaultIndex\": 3, \"page\": 1, \"moveAll\": [234, 242, 249, 252]}, {\"moveAll\": [234, 242, 249, 252], \"defaultIndex\": 3, \"page\": 2}, {\"page\": 3, \"defaultIndex\": 3, \"bright\": [{\"brightValue\": [209, 216, 224, 242], \"brightPage\": \"0\"}]}, {\"defaultIndex\": 3, \"page\": 4, \"bright\": [{\"brightValue\": [229, 229, 252, 252], \"brightPage\": \"0\"}]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 432,
+                "scenceName": "B",
+                "scenceParam": "BSMQAgUBAAL/AADuFBT/AADcFBQC/xQCFQD//wAAAACAEQL9AB0ZAgUBAAH/AADuFBQC/xQC/wAAAAD/AACAEQL+ACkyAAABAAEfAAPmFA8B+A8G/38AAP8AcgD/Df9S/z8A7/8dAwDbEwf/ACMwAwMBAAEhAADpFBQB9hQE//////YByQD//wZDAACAAACAACM3AwMBAAEhAADpFBQB9xQE/wBEqAD///UaAP//AACAAACAAA==",
+                "sceneCode": 2161,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11361,
+                    "scenceParam": "BSMQAgUBAAL/AADuFBT/AADcFBQC/xQCFQD//wAAAACAEQL9AB0ZAgUBAAH/AADuFBQC/xQC/wAAAAD/AACAEQL+ACkyAAABAAEfAAPmFA8B+A8G/38AAP8AcgD/Df9S/z8A7/8dAwDbEwf/ACMwAwMBAAEhAADpFBQB9hQE//////YByQD//wZDAACAAACAACM3AwMBAAEhAADpFBQB9xQE/wBEqAD///UaAP//AACAAACAAA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"bright\":[{\"brightValue\":[220,220,232,220],\"brightPage\":\"1\"}],\"moveAll\":[247,253,255,255],\"page\":0,\"defaultIndex\":1},{\"defaultIndex\":1,\"moveAll\":[247,252,252,255],\"page\":1},{\"moveAll\":[247,252,252,255],\"page\":2,\"defaultIndex\":1,\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[206,206,216,206]}]},{\"defaultIndex\":1,\"page\":3,\"bright\":[{\"brightValue\":[204,204,216,204],\"brightPage\":\"0\"}],\"color\":[242,242,249,242]},{\"bright\":[{\"brightValue\":[204,204,216,204],\"brightPage\":\"0\"}],\"color\":[242,242,249,242],\"page\":4,\"defaultIndex\":1}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31361,
+                    "scenceParam": "BSMQAgUBAAL/AADuFBT/AADcFBQC/xQCFQD//wAAAACAEQL9AB0ZAgUBAAH/AADuFBQC/xQC/wAAAAD/AACAEQL+ACkyAAABAAEfAAPmFA8B+A8G/38AAP8AcgD/Df9S/z8A7/8dAwDbEwf/ACMwAwMBAAEhAADpFBQB9hQE//////YByQD//wZDAACAAACAACM3AwMBAAEhAADpFBQB9xQE/wBEqAD///UaAP//AACAAACAAA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"bright\": [{\"brightValue\": [220, 220, 237, 220], \"brightPage\": \"1\"}], \"moveAll\": [247, 253, 255, 255], \"page\": 0, \"defaultIndex\": 2}, {\"defaultIndex\": 2, \"moveAll\": [247, 252, 252, 255], \"page\": 1}, {\"moveAll\": [247, 252, 252, 255], \"page\": 2, \"defaultIndex\": 2, \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [206, 206, 221, 206]}]}, {\"defaultIndex\": 2, \"page\": 3, \"bright\": [{\"brightValue\": [204, 204, 221, 204], \"brightPage\": \"0\"}], \"color\": [242, 242, 249, 242]}, {\"bright\": [{\"brightValue\": [204, 204, 221, 204], \"brightPage\": \"0\"}], \"color\": [242, 242, 249, 242], \"page\": 4, \"defaultIndex\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 433,
+                "scenceName": "C",
+                "scenceParam": "BBogAgMBAAH//wCAFBQA/yIBALL/EAH9AACAABooAgMBAAH//wCAFBQA/yIB/wCLEgH8AACAACZiAQADAAH//wD/FBQC/wEF/wAA/wAA/0AA//8A//8AFQD/AADNACZiAQADAAH//wD/FBQC/wEF/wAA/wAA/z0A//8A//8AFwD/AgAkAA==",
+                "sceneCode": 2162,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11362,
+                    "scenceParam": "BBogAgMBAAH//wCAFBQA/yIBALL/EAH9AACAABooAgMBAAH//wCAFBQA/yIB/wCLEgH8AACAACZiAQADAAH//wD/FBQC/wEF/wAA/wAA/0AA//8A//8AFQD/AADNACZiAQADAAH//wD/FBQC/wEF/wAA/wAA/z0A//8A//8AFwD/AgAkAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":2,\"moveIn\":[239,247,252,252],\"page\":0},{\"page\":1,\"defaultIndex\":2,\"moveIn\":[239,247,252,252]},{\"page\":2,\"moveIn\":[242,249,252,255],\"defaultIndex\":2},{\"defaultIndex\":2,\"page\":3,\"moveIn\":[242,249,252,255]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31362,
+                    "scenceParam": "BBogAgMBAAH//wCAFBQA/yIBALL/EAH9AACAABooAgMBAAH//wCAFBQA/yIB/wCLEgH8AACAACZiAQADAAH//wD/FBQC/wEF/wAA/wAA/0AA//8A//8AFQD/AADNACZiAQADAAH//wD/FBQC/wEF/wAA/wAA/z0A//8A//8AFwD/AgAkAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\": 3, \"moveIn\": [239, 247, 252, 252], \"page\": 0}, {\"page\": 1, \"defaultIndex\": 3, \"moveIn\": [239, 247, 252, 252]}, {\"page\": 2, \"moveIn\": [242, 249, 252, 255], \"defaultIndex\": 3}, {\"defaultIndex\": 3, \"page\": 3, \"moveIn\": [242, 249, 252, 255]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 395,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/6d31a272b40bce7876f4a53654b8f3cb-new_light_btn_scenes_kapai.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/8f7cea5052c4dcc368150fe86b23b17e-new_light_btn_scenes_kapai_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/62776dc7cd4a4a8b3cfa272e840a2e23-new_light_btn_scenes_kapai_dark.png"
+            ],
+            "sceneName": "Cards Game",
+            "analyticName": "Cards Game",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 434,
+                "scenceName": "",
+                "scenceParam": "AiMAAAAQAAH//wCAFBQCABQEAwD/LP8A/wcA/9UAAADoEgHMABoAAhkBAAH/gADmFBQAgBQB////AACAEADOAA==",
+                "sceneCode": 2163,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11363,
+                    "scenceParam": "AiMAAAAQAAH//wCAFBQCABQEAwD/LP8A/wcA/9UAAADoEgHMABoAAhkBAAH/gADmFBQAgBQB////AACAEADOAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveAll\":[196,204,237],\"page\":0,\"defaultIndex\":1},{\"moveAll\":[196,206,242],\"bright\":[{\"brightValue\":[201,230,230],\"brightPage\":\"0\"}],\"defaultIndex\":1,\"page\":1}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31363,
+                    "scenceParam": "AiMAAAAQAAH//wCAFBQCABQEAwD/LP8A/wcA/9UAAADoEgHMABoAAhkBAAH/gADmFBQAgBQB////AACAEADOAA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveAll\": [196, 214, 237], \"page\": 0, \"defaultIndex\": 2}, {\"moveAll\": [196, 216, 242], \"bright\": [{\"brightValue\": [201, 240, 230], \"brightPage\": \"0\"}], \"defaultIndex\": 2, \"page\": 1}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 396,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/1433558d30ae9ba8d57d0d0d3821ee6f-new_light_btn_scenes_jingsu.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/8a1160d6cdf61f5bf810790c33ee2286-new_light_btn_scenes_jingsu_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/5f49ef11d0082546cdf88a0bca4bcce3-new_light_btn_scenes_jingsu_dark.png"
+            ],
+            "sceneName": "Racing Game",
+            "analyticName": "Racing Game",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 435,
+                "scenceName": "A",
+                "scenceParam": "BSAAAQADAAGrAAABFBQBABQD/38AAAD//38AEAD9AAD4ASAAAQADAAGKAAABFBQBABQDAP///wAAAP//EAD9EADWAiAAAQADAAF6AAABFBQBABQDAP8AAAD/AP8AEAD9EADvAyAAAQADAAGFAAABFBQAABQDAP///wD5AP//EAD9EADzBCAAAQADAAGIAAABFBQAABQDEQD///8AAwD/EAD8EAD4BQ==",
+                "sceneCode": 2164,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11364,
+                    "scenceParam": "BSAAAQADAAGrAAABFBQBABQD/38AAAD//38AEAD9AAD4ASAAAQADAAGKAAABFBQBABQDAP///wAAAP//EAD9EADWAiAAAQADAAF6AAABFBQBABQDAP8AAAD/AP8AEAD9EADvAyAAAQADAAGFAAABFBQAABQDAP///wD5AP//EAD9EADzBCAAAQADAAGIAAABFBQAABQDEQD///8AAwD/EAD8EAD4BQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":1,\"moveIn\":[247,253,253],\"page\":0},{\"page\":1,\"moveIn\":[247,253,253],\"moveAll\":[249,214,255],\"defaultIndex\":1},{\"moveIn\":[247,253,253],\"moveAll\":[247,239,252],\"page\":2,\"defaultIndex\":1},{\"page\":3,\"defaultIndex\":1,\"moveIn\":[247,253,253],\"moveAll\":[247,243,252]},{\"moveAll\":[247,248,252],\"page\":4,\"moveIn\":[247,252,252],\"defaultIndex\":1}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31364,
+                    "scenceParam": "BSAAAQADAAGrAAABFBQBABQD/38AAAD//38AEAD9AAD4ASAAAQADAAGKAAABFBQBABQDAP///wAAAP//EAD9EADWAiAAAQADAAF6AAABFBQBABQDAP8AAAD/AP8AEAD9EADvAyAAAQADAAGFAAABFBQAABQDAP///wD5AP//EAD9EADzBCAAAQADAAGIAAABFBQAABQDEQD///8AAwD/EAD8EAD4BQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\": 2, \"moveIn\": [247, 253, 253], \"page\": 0}, {\"page\": 1, \"moveIn\": [247, 253, 253], \"moveAll\": [249, 224, 255], \"defaultIndex\": 2}, {\"moveIn\": [247, 253, 253], \"moveAll\": [247, 249, 252], \"page\": 2, \"defaultIndex\": 2}, {\"page\": 3, \"defaultIndex\": 2, \"moveIn\": [247, 253, 253], \"moveAll\": [247, 253, 252]}, {\"moveAll\": [247, 248, 252], \"page\": 4, \"moveIn\": [247, 252, 252], \"defaultIndex\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 436,
+                "scenceName": "B",
+                "scenceParam": "BCMAAQADAgH//wD/FBQC/wEE/wAA/wAA/0AA//8AFAD+AAD9ACOAAQADAAH//wD/FBQC/wEE/wCg/wDDiwD///8ABAD+EAD9ACkAAwEBAgEeCAPOBgUC8wEGiwD/iwD/iwD/iwD/AAAAAAAAEgD/AgD/ACOQAQADAAH//wD/FBQC/wEEAAD/AAD/AP////8ABAD+EAD+AA==",
+                "sceneCode": 2165,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11365,
+                    "scenceParam": "BCMAAQADAgH//wD/FBQC/wEE/wAA/wAA/0AA//8AFAD+AAD9ACOAAQADAAH//wD/FBQC/wEE/wCg/wDDiwD///8ABAD+EAD9ACkAAwEBAgEeCAPOBgUC8wEGiwD/iwD/iwD/iwD/AAAAAAAAEgD/AgD/ACOQAQADAAH//wD/FBQC/wEEAAD/AAD/AP////8ABAD+EAD+AA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\":[242,252,255],\"defaultIndex\":1,\"page\":0},{\"moveAll\":[242,253,255],\"page\":1,\"defaultIndex\":1},{\"moveIn\":[237,249,252],\"page\":2,\"defaultIndex\":1},{\"defaultIndex\":1,\"moveAll\":[242,252,255],\"page\":3}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31365,
+                    "scenceParam": "BCMAAQADAgH//wD/FBQC/wEE/wAA/wAA/0AA//8AFAD+AAD9ACOAAQADAAH//wD/FBQC/wEE/wCg/wDDiwD///8ABAD+EAD9ACkAAwEBAgEeCAPOBgUC8wEGiwD/iwD/iwD/iwD/AAAAAAAAEgD/AgD/ACOQAQADAAH//wD/FBQC/wEEAAD/AAD/AP////8ABAD+EAD+AA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\": [242, 252, 255], \"defaultIndex\": 2, \"page\": 0}, {\"moveAll\": [242, 253, 255], \"page\": 1, \"defaultIndex\": 2}, {\"moveIn\": [237, 249, 252], \"page\": 2, \"defaultIndex\": 2}, {\"defaultIndex\": 2, \"moveAll\": [242, 252, 255], \"page\": 3}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 397,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/7ba26849d6f85db40e8f29b45994cfd1-new_light_btn_scenes_juese.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/db791a012edf6b036aa2acd3db2d9d23-new_light_btn_scenes_juese_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/87fb2ab74d8ec43c99bb9dda30d433de-new_light_btn_scenes_juese_dark.png"
+            ],
+            "sceneName": "Cosplay",
+            "analyticName": "Cosplay",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 437,
+                "scenceName": "",
+                "scenceParam": "AiYAAwIDAAH//wDyFBQB/xQFAAD/AP//AAAAAAAA/wAAAACAEQD9ASAAAwYBAAESAACAFBQDgBQDiwD/AAAAAAD/EQD7AACAAA==",
+                "sceneCode": 2166,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11366,
+                    "scenceParam": "AiYAAwIDAAH//wDyFBQB/xQFAAD/AP//AAAAAAAA/wAAAACAEQD9ASAAAwYBAAESAACAFBQDgBQDiwD/AAAAAAD/EQD7AACAAA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"color\":[232,239,247,255],\"moveAll\":[229,242,249,249],\"page\":0,\"defaultIndex\":2},{\"moveIn\":[229,242,251,251],\"defaultIndex\":2,\"page\":1}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31366,
+                    "scenceParam": "AiYAAwIDAAH//wDyFBQB/xQFAAD/AP//AAAAAAAA/wAAAACAEQD9ASAAAwYBAAESAACAFBQDgBQDiwD/AAAAAAD/EQD7AACAAA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"color\": [232, 239, 247, 255], \"moveAll\": [229, 242, 249, 249], \"page\": 0, \"defaultIndex\": 3}, {\"moveIn\": [229, 242, 251, 251], \"defaultIndex\": 3, \"page\": 1}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 398,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/749a0d926d938a2f2d6d4e342e1eaaf3-new_light_btn_scenes_gedou.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/8587e81275bfc086d414c6a451b7601a-new_light_btn_scenes_gedou_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/de77e7044a63ed31aa598feffbabecde-new_light_btn_scenes_gedou_dark.png"
+            ],
+            "sceneName": "Fighting Game",
+            "analyticName": "Fighting Game",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 438,
+                "scenceName": "A",
+                "scenceParam": "BB0AAAABAAF7ewIAFBQAsxQC////AAAAAACAAACAAR0XAAABAAH/AACAFBQBABQC/wAAAAAAEwD/EwD/BR0SAAABAAH/AACAFBQBABQC/wAAAAAAEQD/EQD/BSMAAAAIAAH//wAAFBQC9QEEAAAA/38AAAAA//UIAACAAACAAQ==",
+                "sceneCode": 2167,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11367,
+                    "scenceParam": "BB0AAAABAAF7ewIAFBQAsxQC////AAAAAACAAACAAR0XAAABAAH/AACAFBQBABQC/wAAAAAAEwD/EwD/BR0SAAABAAH/AACAFBQBABQC/wAAAAAAEQD/EQD/BSMAAAAIAAH//wAAFBQC9QEEAAAA/38AAAAA//UIAACAAACAAQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":1,\"page\":1,\"moveAll\":[247,252,255],\"moveIn\":[247,252,252]},{\"moveAll\":[247,252,255],\"page\":2,\"defaultIndex\":1,\"moveIn\":[247,252,252]},{\"defaultIndex\":1,\"color\":[237,245,245],\"page\":3}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31367,
+                    "scenceParam": "BB0AAAABAAF7ewIAFBQAsxQC////AAAAAACAAACAAR0XAAABAAH/AACAFBQBABQC/wAAAAAAEwD/EwD/BR0SAAABAAH/AACAFBQBABQC/wAAAAAAEQD/EQD/BSMAAAAIAAH//wAAFBQC9QEEAAAA/38AAAAA//UIAACAAACAAQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\": 2, \"page\": 1, \"moveAll\": [247, 252, 255], \"moveIn\": [247, 252, 252]}, {\"moveAll\": [247, 252, 255], \"page\": 2, \"defaultIndex\": 2, \"moveIn\": [247, 252, 252]}, {\"defaultIndex\": 2, \"color\": [242, 250, 250], \"page\": 3}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 439,
+                "scenceName": "B",
+                "scenceParam": "AxoAAAABAAH//wB/FBQAfxQBALT/AAB/AAB/ASkAAAAFAAH//wB/FBQCABQG/wBs/woA/10AAAAAAAAAAAAAEAD/AAB/AikAAAAFAAH//wB/FBQCABQG/wBs/woA/10AAAAAAAAAAAAAEgD/AAB/Ag==",
+                "sceneCode": 2168,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11368,
+                    "scenceParam": "AxoAAAABAAH//wB/FBQAfxQBALT/AAB/AAB/ASkAAAAFAAH//wB/FBQCABQG/wBs/woA/10AAAAAAAAAAAAAEAD/AAB/AikAAAAFAAH//wB/FBQCABQG/wBs/woA/10AAAAAAAAAAAAAEgD/AAB/Ag==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\":[239,247,252,255],\"page\":1,\"defaultIndex\":2},{\"defaultIndex\":2,\"moveIn\":[239,247,252,255],\"page\":2}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31368,
+                    "scenceParam": "AxoAAAABAAH//wB/FBQAfxQBALT/AAB/AAB/ASkAAAAFAAH//wB/FBQCABQG/wBs/woA/10AAAAAAAAAAAAAEAD/AAB/AikAAAAFAAH//wB/FBQCABQG/wBs/woA/10AAAAAAAAAAAAAEgD/AAB/Ag==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\": [239, 247, 252, 255], \"page\": 1, \"defaultIndex\": 3}, {\"defaultIndex\": 3, \"moveIn\": [239, 247, 252, 255], \"page\": 2}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 399,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/f5715bc7f4e3108beb4441466be374af-new_light_btn_scenes_maoxian.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/f67ad035bcaf42608bbd7b710b0dcce3-new_light_btn_scenes_maoxian_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/87db254ee11649b2c7f9a3df40be0f96-new_light_btn_scenes_maoxian_dark.png"
+            ],
+            "sceneName": "Adventure Game",
+            "analyticName": "Adventure Game",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 440,
+                "scenceName": "A",
+                "scenceParam": "Ax1GAAACAAH/AACAFBQCAP8C/wAAiwD/EAD9EgD1BR1AAAACAAH/AACAFBQCAP8C/wAAiwD/EgD9EAD1BRoAAAABAAEdHQAAFBQAAP8BiwD/AACAAACAAQ==",
+                "sceneCode": 2169,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11369,
+                    "scenceParam": "Ax1GAAACAAH/AACAFBQCAP8C/wAAiwD/EAD9EgD1BR1AAAACAAH/AACAFBQCAP8C/wAAiwD/EgD9EAD1BRoAAAABAAEdHQAAFBQAAP8BiwD/AACAAACAAQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\":[232,242,249,252],\"page\":0,\"defaultIndex\":3},{\"page\":1,\"moveIn\":[232,242,249,252],\"defaultIndex\":3}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31369,
+                    "scenceParam": "Ax1GAAACAAH/AACAFBQCAP8C/wAAiwD/EAD9EgD1BR1AAAACAAH/AACAFBQCAP8C/wAAiwD/EgD9EAD1BRoAAAABAAEdHQAAFBQAAP8BiwD/AACAAACAAQ==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveIn\": [232, 242, 249, 252], \"page\": 0, \"defaultIndex\": 4}, {\"page\": 1, \"moveIn\": [232, 242, 249, 252], \"defaultIndex\": 4}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 441,
+                "scenceName": "B",
+                "scenceParam": "AxoAAAABAAGzswCAFBQAgBQBAP8AAACAAACAACBEAwMSAAH/AAD/ZH0BABQD//8A//////8AAACAAACAAB0ZAQACAAH/AACAFBQBABQC/wAAAAD/AACAEgH3Ag==",
+                "sceneCode": 2170,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11370,
+                    "scenceParam": "AxoAAAABAAGzswCAFBQAgBQBAP8AAACAAACAACBEAwMSAAH/AAD/ZH0BABQD//8A//////8AAACAAACAAB0ZAQACAAH/AACAFBQBABQC/wAAAAD/AACAEgH3Ag==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\":2,\"moveAll\":[229,239,247,252],\"defaultIndex\":2}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31370,
+                    "scenceParam": "AxoAAAABAAGzswCAFBQAgBQBAP8AAACAAACAACBEAwMSAAH/AAD/ZH0BABQD//8A//////8AAACAAACAAB0ZAQACAAH/AACAFBQBABQC/wAAAAD/AACAEgH3Ag==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\": 2, \"moveAll\": [229, 239, 247, 252], \"defaultIndex\": 3}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 400,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/50c9b8b6e343b5dff7f3838321f0ff6d-new_light_btn_scenes_yizhi.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/4edb3dc198756b9dee4671ef1810c0aa-new_light_btn_scenes_yizhi_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/f2f28fedafc86dbe8edba4cdcb53df63-new_light_btn_scenes_yizhi_dark.png"
+            ],
+            "sceneName": "Puzzle Game",
+            "analyticName": "Puzzle Game",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 442,
+                "scenceName": "A",
+                "scenceParam": "ASMAAwICAAH/AACAFBQAgQUEAAD//wAA/wf/B/3/EQP3AACAAA==",
+                "sceneCode": 2171,
+                "specialEffect": [],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 443,
+                "scenceName": "B",
+                "scenceParam": "BRoQAAABAAH/AAH/GRkAgBQB/wAAAACAAACAABoZAAABAAH//wD/KDIAgBQBbgD/AACAAACAABpxAQABAAH/AACAFBQAgBQB////EQD/AQD/ABoYAAABAAH/AAH/GRQCABQBIv8AAACAAgD/ABowAQABAAH/AACAFBQA+xQB//8AAACAEgD/AA==",
+                "sceneCode": 2172,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11371,
+                    "scenceParam": "BRoQAAABAAH/AAH/GRkAgBQB/wAAAACAAACAABoZAAABAAH//wD/KDIAgBQBbgD/AACAAACAABpxAQABAAH/AACAFBQAgBQB////EQD/AQD/ABoYAAABAAH/AAH/GRQCABQBIv8AAACAAgD/ABowAQABAAH/AACAFBQA+xQB//8AAACAEgD/AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":1,\"page\":0,\"bright\":[{\"brightValue\":[226,255,255],\"brightPage\":\"0\"}]},{\"defaultIndex\":1,\"bright\":[{\"brightValue\":[226,255,255],\"brightPage\":\"0\"}],\"page\":1},{\"page\":2,\"defaultIndex\":1,\"moveIn\":[242,252,255]},{\"defaultIndex\":1,\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[226,255,255]}],\"page\":3},{\"defaultIndex\":1,\"moveAll\":[242,252,255],\"page\":4}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31371,
+                    "scenceParam": "BRoQAAABAAH/AAH/GRkAgBQB/wAAAACAAACAABoZAAABAAH//wD/KDIAgBQBbgD/AACAAACAABpxAQABAAH/AACAFBQAgBQB////EQD/AQD/ABoYAAABAAH/AAH/GRQCABQBIv8AAACAAgD/ABowAQABAAH/AACAFBQA+xQB//8AAACAEgD/AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\": 2, \"page\": 0, \"bright\": [{\"brightValue\": [226, 255, 255], \"brightPage\": \"0\"}]}, {\"defaultIndex\": 2, \"bright\": [{\"brightValue\": [226, 255, 255], \"brightPage\": \"0\"}], \"page\": 1}, {\"page\": 2, \"defaultIndex\": 2, \"moveIn\": [242, 252, 255]}, {\"defaultIndex\": 2, \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [226, 255, 255]}], \"page\": 3}, {\"defaultIndex\": 2, \"moveAll\": [242, 252, 255], \"page\": 4}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 444,
+                "scenceName": "C",
+                "scenceParam": "BRogAAABAAH/AACAFBQAgBQB//8AFADBEAC9ABoiAAABAAH/AACAFBQAgBQB/wAAFADAEAC9ABokAAABAAH/AACAFBQAgBQBAAD/FADBEADAABomAAABAAH/AACAFBQAgBQBAP8AFAC/EAC/ABooAAACAAH/AACAFBQAgBQBiwD/FADBEAC/AA==",
+                "sceneCode": 2173,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11372,
+                    "scenceParam": "BRogAAABAAH/AACAFBQAgBQB//8AFADBEAC9ABoiAAABAAH/AACAFBQAgBQB/wAAFADAEAC9ABokAAABAAH/AACAFBQAgBQBAAD/FADBEADAABomAAABAAH/AACAFBQAgBQBAP8AFAC/EAC/ABooAAACAAH/AACAFBQAgBQBiwD/FADBEAC/AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveAll\":[189,234,242,249],\"defaultIndex\":0,\"moveIn\":[193,234,242,249],\"page\":0},{\"page\":1,\"moveIn\":[192,234,242,249],\"defaultIndex\":0,\"moveAll\":[189,234,242,249]},{\"page\":2,\"moveAll\":[192,234,242,249],\"moveIn\":[193,234,242,249],\"defaultIndex\":0},{\"defaultIndex\":0,\"moveAll\":[191,234,242,249],\"moveIn\":[191,234,242,249],\"page\":3},{\"moveAll\":[191,234,242,249],\"moveIn\":[193,234,242,249],\"page\":4,\"defaultIndex\":0}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31372,
+                    "scenceParam": "BRogAAABAAH/AACAFBQAgBQB//8AFADBEAC9ABoiAAABAAH/AACAFBQAgBQB/wAAFADAEAC9ABokAAABAAH/AACAFBQAgBQBAAD/FADBEADAABomAAABAAH/AACAFBQAgBQBAP8AFAC/EAC/ABooAAACAAH/AACAFBQAgBQBiwD/FADBEAC/AA==",
+                    "cmdVersion": 0,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveAll\": [189, 234, 242, 249], \"defaultIndex\": 1, \"moveIn\": [193, 234, 242, 249], \"page\": 0}, {\"page\": 1, \"moveIn\": [192, 234, 242, 249], \"defaultIndex\": 1, \"moveAll\": [189, 234, 242, 249]}, {\"page\": 2, \"moveAll\": [192, 234, 242, 249], \"moveIn\": [193, 234, 242, 249], \"defaultIndex\": 1}, {\"defaultIndex\": 1, \"moveAll\": [191, 234, 242, 249], \"moveIn\": [191, 234, 242, 249], \"page\": 3}, {\"moveAll\": [191, 234, 242, 249], \"moveIn\": [193, 234, 242, 249], \"page\": 4, \"defaultIndex\": 1}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 445,
+                "scenceName": "D",
+                "scenceParam": "BSkAAysUAAGoAACAFBQBABQGAP//AAAAiwD//wD/AAAAAAAAAACAAACAACkAAwUoAAH/AACAFBQDgBQGAB//AAAA/wD7AAAAAAAAAAAAEgD6EgDwASkAAwUFAAF0AACAFBQAgBQGAP//AAAAAAAA/wDiAAAAAAAAEAD8AACAAikAAQAyAAH/AACAFBQD9RQG/wAAAAAAAAAAAP//AAAAAAAAEAD+AACAAykAAyAwAAGAAACAFBQBgBQGAP//AAAAAAAAAAAA/wDoAAAAFAD9AACABQ==",
+                "sceneCode": 2174,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11373,
+                    "scenceParam": "BSkAAysUAAGoAACAFBQBABQGAP//AAAAiwD//wD/AAAAAAAAAACAAACAACkAAwUoAAH/AACAFBQDgBQGAB//AAAA/wD7AAAAAAAAAAAAEgD6EgDwASkAAwUFAAF0AACAFBQAgBQGAP//AAAAAAAA/wDiAAAAAAAAEAD8AACAAikAAQAyAAH/AACAFBQD9RQG/wAAAAAAAAAAAP//AAAAAAAAEAD+AACAAykAAyAwAAGAAACAFBQBgBQGAP//AAAAAAAAAAAA/wDoAAAAFAD9AACABQ==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveAll\":[232,240,240,255],\"page\":1,\"defaultIndex\":2,\"moveIn\":[242,250,250,252]},{\"page\":2,\"moveIn\":[239,247,252,252],\"defaultIndex\":2},{\"defaultIndex\":2,\"moveIn\":[239,252,254,254],\"color\":[245,245,245,249],\"page\":3},{\"moveIn\":[239,247,253,253],\"page\":4,\"defaultIndex\":2}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31373,
+                    "scenceParam": "BSkAAysUAAGoAACAFBQBABQGAP//AAAAiwD//wD/AAAAAAAAAACAAACAACkAAwUoAAH/AACAFBQDgBQGAB//AAAA/wD7AAAAAAAAAAAAEgD6EgDwASkAAwUFAAF0AACAFBQAgBQGAP//AAAAAAAA/wDiAAAAAAAAEAD8AACAAikAAQAyAAH/AACAFBQD9RQG/wAAAAAAAAAAAP//AAAAAAAAEAD+AACAAykAAyAwAAGAAACAFBQBgBQGAP//AAAAAAAAAAAA/wDoAAAAFAD9AACABQ==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"moveAll\": [232, 240, 240, 255], \"page\": 1, \"defaultIndex\": 3, \"moveIn\": [242, 250, 250, 252]}, {\"page\": 2, \"moveIn\": [239, 247, 252, 252], \"defaultIndex\": 3}, {\"defaultIndex\": 3, \"moveIn\": [239, 252, 254, 254], \"color\": [245, 245, 245, 249], \"page\": 3}, {\"moveIn\": [239, 247, 253, 253], \"page\": 4, \"defaultIndex\": 3}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              },
+              {
+                "scenceParamId": 446,
+                "scenceName": "E",
+                "scenceParam": "BCkZAAABAAH/AAD1FBQB/xQG/+AhAAAA/yoDAAAAA/8AAAAAAACAEAH/ACkQAAABAAH/AAD3FBQB/xQG//8AAAAA/wkAAAAADf8AAAAAAACAEgH/ACMAAwEBAAGsAAH/KBQA/xQEuAD/MC7/zAD//38AAACAAACAACAkAwMCAAGkAAP/PBQA/xQDAP//JB3/AP//AACAETD/AA==",
+                "sceneCode": 2175,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11374,
+                    "scenceParam": "BCkZAAABAAH/AAD1FBQB/xQG/+AhAAAA/yoDAAAAA/8AAAAAAACAEAH/ACkQAAABAAH/AAD3FBQB/xQG//8AAAAA/wkAAAAADf8AAAAAAACAEgH/ACMAAwEBAAGsAAH/KBQA/xQEuAD/MC7/zAD//38AAACAAACAACAkAwMCAAGkAAP/PBQA/xQDAP//JB3/AP//AACAETD/AA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":2,\"page\":0,\"moveAll\":[242,249,255]},{\"moveAll\":[242,249,255],\"page\":1,\"defaultIndex\":2},{\"defaultIndex\":2,\"moveAll\":[242,249,255],\"page\":3}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31374,
+                    "scenceParam": "BCkZAAABAAH/AAD1FBQB/xQG/+AhAAAA/yoDAAAAA/8AAAAAAACAEAH/ACkQAAABAAH/AAD3FBQB/xQG//8AAAAA/wkAAAAADf8AAAAAAACAEgH/ACMAAwEBAAGsAAH/KBQA/xQEuAD/MC7/zAD//38AAACAAACAACAkAwMCAAGkAAP/PBQA/xQDAP//JB3/AP//AACAETD/AA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"defaultIndex\":2,\"page\":0,\"moveAll\":[242,249,255]},{\"moveAll\":[242,249,255],\"page\":1,\"defaultIndex\":2},{\"defaultIndex\":2,\"moveAll\":[242,249,255],\"page\":3}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          }
+        ]
+      },
+      {
+        "categoryId": 118,
+        "categoryName": "Relaxation",
+        "scenes": [
+          {
+            "sceneId": 661,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/2540c7a5f8670c8dccf5243f243de21c-new_light_btn_scenes_fadai.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/0afc5f64f6c923ebc34b9abe3d25d348-new_light_btn_scenes_fadai_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/fbaae1c57d3737e0174f273c71ab8c45-new_light_btn_scenes_fadai_dark.png"
+            ],
+            "sceneName": "Daze",
+            "analyticName": "Daze",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 709,
+                "scenceName": "",
+                "scenceParam": "AyAAAhAQAAH/AAPLS0sBoAED1f8n/4kl+P8nAQDeAACAACAAAhAQAAH/AAHLS0sBoAED/2TFQDr+xF3/AQDeAACAABoAAAABAAEICAEAS0sBAAEB////AQDeAACAAA==",
+                "sceneCode": 2202,
+                "specialEffect": [],
+                "cmdVersion": 0,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          },
+          {
+            "sceneId": 662,
+            "iconUrls": [
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/71243368d569beaf8c4472b4033c6df5-new_light_btn_scenes_qichuang.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/93460ee85c7599d4904f77f6ad2a5d96-new_light_btn_scenes_qichuang_press.png",
+              "https://d1f2504ijhdyjw.cloudfront.net/deals-img/d9545683ff3e15e4c1d8799a61ebe5b1-new_light_btn_scenes_qichuang_dark.png"
+            ],
+            "sceneName": "Awaken",
+            "analyticName": "Awaken",
+            "sceneType": 2,
+            "sceneCode": 0,
+            "scenceCategoryId": 0,
+            "popUpPrompt": 0,
+            "scenesHint": "",
+            "rule": {
+              "maxSoftVersion": "",
+              "minSoftVersion": "",
+              "maxHardVersion": "",
+              "minHardVersion": "",
+              "maxWifiSoftVersion": "",
+              "minWifiSoftVersion": "",
+              "maxWifiHardVersion": "",
+              "minWifiHardVersion": ""
+            },
+            "lightEffects": [
+              {
+                "scenceParamId": 711,
+                "scenceName": "",
+                "scenceParam": "AyMlAAABAAH/gAG1FBQD6BQECW7/SJ7///31AAAAAACAEAD/ACMjAAABAAH/gQG1FBQD5hQECW7/SJ7///31AAAAAACAEgD/ABoAAhEBAAH/AAL/FGQAgBQB////AACAEQDtAA==",
+                "sceneCode": 2204,
+                "specialEffect": [
+                  {
+                    "scenceParamId": 11380,
+                    "scenceParam": "AyMlAAABAAH/gAG1FBQD6BQECW7/SJ7///31AAAAAACAEAD/ACMjAAABAAH/gQG1FBQD5hQECW7/SJ7///31AAAAAACAEgD/ABoAAhEBAAH/AAL/FGQAgBQB////AACAEQDtAA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617C"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\":0,\"defaultIndex\":2,\"moveAll\":[239,247,252]},{\"page\":1,\"defaultIndex\":2,\"moveAll\":[239,247,252]},{\"page\":2,\"bright\":[{\"brightPage\":\"0\",\"brightValue\":[249,255,255]}],\"defaultIndex\":2,\"moveAll\":[221,229,237]}]",
+                      "speedIndex": 0,
+                      "supSpeed": true
+                    }
+                  },
+                  {
+                    "scenceParamId": 31380,
+                    "scenceParam": "AyMlAAABAAH/gAG1FBQD6BQECW7/SJ7///31AAAAAACAEAD/ACMjAAABAAH/gQG1FBQD5hQECW7/SJ7///31AAAAAACAEgD/ABoAAhEBAAH/AAL/FGQAgBQB////AACAEQDtAA==",
+                    "cmdVersion": 1,
+                    "supportSku": [
+                      "H617A"
+                    ],
+                    "speedInfo": {
+                      "config": "[{\"page\": 0, \"defaultIndex\": 2, \"moveAll\": [239, 247, 252]}, {\"page\": 1, \"defaultIndex\": 2, \"moveAll\": [239, 247, 252]}, {\"page\": 2, \"bright\": [{\"brightPage\": \"0\", \"brightValue\": [249, 255, 255]}], \"defaultIndex\": 2, \"moveAll\": [221, 239, 237]}]",
+                      "speedIndex": 1,
+                      "supSpeed": true
+                    }
+                  }
+                ],
+                "cmdVersion": 1,
+                "sceneType": 2,
+                "diyEffectCode": [],
+                "diyEffectStr": "",
+                "rules": [],
+                "speedInfo": {
+                  "config": "",
+                  "speedIndex": 0,
+                  "supSpeed": false
+                }
+              }
+            ],
+            "voiceUrl": ""
+          }
+        ]
+      }
+    ],
+    "supportSpeed": 1
+  }
+}

--- a/custom_components/govee-ble-lights/light.py
+++ b/custom_components/govee-ble-lights/light.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import array
+import asyncio
 import logging
 import re
 
@@ -14,8 +15,10 @@ from homeassistant.components.light import (ATTR_BRIGHTNESS, ATTR_RGB_COLOR, ATT
 
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.event import async_call_later
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.storage import Store
-import homeassistant.util.color as color_util
 
 from .const import DOMAIN
 from pathlib import Path
@@ -23,16 +26,28 @@ import json
 from .govee_utils import prepareMultiplePacketsData
 import base64
 from . import Hub
-from datetime import timedelta
-
-SCAN_INTERVAL = timedelta(seconds=30)
-
 
 _LOGGER = logging.getLogger(__name__)
 
 UUID_CONTROL_CHARACTERISTIC = '00010203-0405-0607-0809-0a0b0c0d2b11'
-EFFECT_PARSE = re.compile("\[(\d+)/(\d+)/(\d+)/(\d+)]")
-SEGMENTED_MODELS = ['H6053', 'H6072', 'H6102', 'H6199']
+EFFECT_PARSE = re.compile(r"\[(\d+)/(\d+)/(\d+)/(\d+)]")
+SEGMENTED_MODELS = ['H6053', 'H6072', 'H6102', 'H6199', 'H617A', 'H617C']
+PERCENT_MODELS = ['H617A']
+
+# Number of BLE write attempts before a command is reported as failed.
+MAX_COMMAND_ATTEMPTS = 3
+
+# A dynamic scene needs the BLE link held open for a few seconds after upload to
+# commit (then it persists, like closing the Govee app). We keep the connection
+# open after every command and close it only after this idle window, so we don't
+# permanently hold one of the BLE proxy's limited connection slots per strip.
+IDLE_DISCONNECT_SECONDS = 15
+
+# These strips share a single Bluetooth adapter. Serialize connection
+# *establishment* across all entities so concurrent connects to different
+# devices don't fight over the one radio. Actual writes still run in parallel
+# once each entity holds its own connection.
+_CONNECT_LOCK = asyncio.Lock()
 
 class LedCommand(IntEnum):
     """ A control command packet's type. """
@@ -97,15 +112,11 @@ class GoveeAPILight(LightEntity, dict):
                 color_modes.add(ColorMode.BRIGHTNESS)
             if cap['instance'] == 'colorTemperatureK':
                 color_modes.add(ColorMode.COLOR_TEMP)
-                self._attr_min_color_temp_kelvin = cap['parameters']['range']['min']
-                self._attr_max_color_temp_kelvin = cap['parameters']['range']['max']
-                self._attr_min_mireds = color_util.color_temperature_kelvin_to_mired(self._attr_min_color_temp_kelvin)
-                self._attr_max_mireds = color_util.color_temperature_kelvin_to_mired(self._attr_max_color_temp_kelvin)
             if cap['instance'] == 'colorRgb':
                 color_modes.add(ColorMode.RGB)
             if cap['instance'] == 'lightScene':
                 self._attr_supported_features = LightEntityFeature(
-                    LightEntityFeature.EFFECT | LightEntityFeature.FLASH | LightEntityFeature.TRANSITION
+                    LightEntityFeature.EFFECT
                 )
 
         if ColorMode.ONOFF in color_modes:
@@ -119,29 +130,12 @@ class GoveeAPILight(LightEntity, dict):
 
         self._state = None
         self._brightness = None
-        self.update_scenes()
 
     async def async_update(self):
         """Retrieve latest state."""
         _LOGGER.info("Updating device: %s", self.device_data)
 
-        state = await self.hub.api.get_device_state(self.sku, self.device)
-        for cap in state["capabilities"]:
-            if cap['instance'] == 'powerSwitch':
-                self._state = cap['state']['value'] == 1
-            if cap['instance'] == 'brightness':
-                self._brightness = cap['state']['value']
-            if cap['instance'] == 'colorTemperatureK':
-                value = cap['state']['value']
-                if value != 0:
-                    self._attr_color_temp_kelvin = value
-                    self._attr_color_temp = color_util.color_temperature_kelvin_to_mired(value)
-            if cap['instance'] == 'colorRgb':
-                num = cap['state']['value']
-                self._attr_rgb_color = ((num >> 16) & 0xFF, (num >> 8) & 0xFF, num & 0xFF)
-
-    async def update_scenes(self):
-        if LightEntityFeature.EFFECT in self.supported_features:
+        if LightEntityFeature.EFFECT in self.supported_features_compat:
             if self._attr_effect_list is None or len(self._attr_effect_list) == 0:
                 _LOGGER.info("Updating device effects: %s", self.device_data)
 
@@ -173,8 +167,8 @@ class GoveeAPILight(LightEntity, dict):
 
         if ATTR_BRIGHTNESS in kwargs:
             brightness = kwargs.get(ATTR_BRIGHTNESS, 255)
-            await self.hub.api.set_brightness(self.sku, self.device, (brightness / 255) * 100)
             self._brightness = brightness
+            await self.hub.api.set_brightness(self.sku, self.device, (brightness / 255) * 100)
 
         if ATTR_RGB_COLOR in kwargs:
             red, green, blue = kwargs.get(ATTR_RGB_COLOR)
@@ -198,11 +192,11 @@ class GoveeAPILight(LightEntity, dict):
         await self.hub.api.toggle_power(self.sku, self.device, 1)
 
     async def async_turn_off(self, **kwargs) -> None:
-        await self.hub.api.toggle_power(self.sku, self.device, 0)
         self._state = False
+        await self.hub.api.toggle_power(self.sku, self.device, 0)
 
 
-class GoveeBluetoothLight(LightEntity):
+class GoveeBluetoothLight(RestoreEntity, LightEntity):
     _attr_color_mode = ColorMode.RGB
     _attr_supported_color_modes = {ColorMode.RGB}
     _attr_supported_features = LightEntityFeature(
@@ -213,27 +207,97 @@ class GoveeBluetoothLight(LightEntity):
         self._mac = hub.address
         self._model = config_entry.data["model"]
         self._is_segmented = self._model in SEGMENTED_MODELS
+        self._use_percent = self._model in PERCENT_MODELS
         self._ble_device = ble_device
         self._state = None
         self._brightness = None
+        self._rgb_color = None
+        self._effect = None
 
-    @property
-    def effect_list(self) -> list[str] | None:
-        effect_list = []
-        json_data = json.loads(Path(Path(__file__).parent / "jsons" / (self._model + ".json")).read_text())
-        for categoryIdx, category in enumerate(json_data['data']['categories']):
-            for sceneIdx, scene in enumerate(category['scenes']):
-                for leffectIdx, lightEffect in enumerate(scene['lightEffects']):
-                    for seffectIxd, specialEffect in enumerate(lightEffect['specialEffect']):
-                        # if 'supportSku' not in specialEffect or self._model in specialEffect['supportSku']:
-                        # Workaround cause we need to store some metadata in effect (effect names not unique)
-                        indexes = str(categoryIdx) + "/" + str(sceneIdx) + "/" + str(leffectIdx) + "/" + str(
-                            seffectIxd)
-                        effect_list.append(
-                            category['categoryName'] + " - " + scene['sceneName'] + ' - ' + lightEffect[
-                                'scenceName'] + " [" + indexes + "]")
+        # Serialize a single device's command sequences so the chunked packets
+        # of one scene are never interleaved with another command.
+        self._command_lock = asyncio.Lock()
+        # Connection is held open between commands (so scenes commit) and closed
+        # on an idle timer. A fresh one is established for every command.
+        self._client: BleakClient | None = None
+        self._idle_disconnect_cancel = None
 
-        return effect_list
+        # Effect catalogue, parsed once off the event loop in async_added_to_hass.
+        self._effect_indexes: dict[str, tuple[int, int, int, int]] = {}
+        self._model_json: dict | None = None
+        self._attr_effect_list = []
+
+    async def async_added_to_hass(self) -> None:
+        """Restore prior state and load the effect catalogue (off the event loop)."""
+        await super().async_added_to_hass()
+
+        last_state = await self.async_get_last_state()
+        if last_state is not None and last_state.state not in (None, "unavailable", "unknown"):
+            self._state = last_state.state == "on"
+            self._brightness = last_state.attributes.get("brightness")
+            rgb = last_state.attributes.get("rgb_color")
+            self._rgb_color = tuple(rgb) if rgb else None
+            self._effect = last_state.attributes.get("effect")
+
+        await self._async_load_effects()
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Cancel the idle timer and drop the BLE link when the entity goes away."""
+        self._cancel_idle_disconnect()
+        await self._disconnect()
+
+    async def _async_load_effects(self) -> None:
+        """Parse jsons/<MODEL>.json once and build a clean name -> indices map.
+
+        The bundled catalogue lists every special-effect variant with a cryptic
+        ``[c/s/le/se]`` suffix. We collapse to one entry per light-effect and
+        render readable ``Category - Scene[ - Sub]`` names instead.
+        """
+        path = Path(__file__).parent / "jsons" / f"{self._model}.json"
+
+        def _load() -> dict:
+            with open(path, "r", encoding="utf-8") as handle:
+                return json.load(handle)
+
+        try:
+            data = await self.hass.async_add_executor_job(_load)
+        except FileNotFoundError:
+            _LOGGER.warning("Govee %s: no effect catalogue for model %s at %s",
+                            self._mac, self._model, path)
+            return
+        except Exception as err:  # noqa: BLE001 - surface a bad/corrupt file, keep light usable
+            _LOGGER.warning("Govee %s: failed to parse %s: %s", self._mac, path, err)
+            return
+
+        names: list[str] = []
+        indexes: dict[str, tuple[int, int, int, int]] = {}
+
+        for category_idx, category in enumerate(data.get('data', {}).get('categories', [])):
+            category_name = category.get('categoryName', f"Category {category_idx}")
+            for scene_idx, scene in enumerate(category.get('scenes', [])):
+                scene_name = scene.get('sceneName', '').strip()
+                for light_idx, light_effect in enumerate(scene.get('lightEffects', [])):
+                    specials = light_effect.get('specialEffect') or []
+                    if not specials:
+                        continue
+                    sub_name = (light_effect.get('scenceName') or '').strip()
+                    label = f"{category_name} - {scene_name}" if scene_name else category_name
+                    if sub_name:
+                        label = f"{label} - {sub_name}"
+                    # Disambiguate the rare genuine name collision.
+                    display = label
+                    suffix = 2
+                    while display in indexes:
+                        display = f"{label} ({suffix})"
+                        suffix += 1
+                    # Collapse variants: first special-effect carries a usable payload.
+                    indexes[display] = (category_idx, scene_idx, light_idx, 0)
+                    names.append(display)
+
+        self._model_json = data
+        self._effect_indexes = indexes
+        self._attr_effect_list = names
+        self.async_write_ha_state()
 
     @property
     def name(self) -> str:
@@ -246,8 +310,23 @@ class GoveeBluetoothLight(LightEntity):
         return self._mac.replace(":", "")
 
     @property
+    def available(self) -> bool:
+        """Report unavailable when HA's Bluetooth stack can't currently see the strip."""
+        if self.hass is None:
+            return False
+        return bluetooth.async_address_present(self.hass, self._mac.upper(), True)
+
+    @property
     def brightness(self):
         return self._brightness
+
+    @property
+    def rgb_color(self) -> tuple[int, int, int] | None:
+        return self._rgb_color
+
+    @property
+    def effect(self) -> str | None:
+        return self._effect
 
     @property
     def is_on(self) -> bool | None:
@@ -257,12 +336,18 @@ class GoveeBluetoothLight(LightEntity):
     async def async_turn_on(self, **kwargs) -> None:
         commands = [self._prepareSinglePacketData(LedCommand.POWER, [0x1])]
 
-        self._state = True
+        new_brightness = self._brightness
+        new_rgb = self._rgb_color
+        new_effect = self._effect
 
         if ATTR_BRIGHTNESS in kwargs:
             brightness = kwargs.get(ATTR_BRIGHTNESS, 255)
-            commands.append(self._prepareSinglePacketData(LedCommand.BRIGHTNESS, [brightness]))
-            self._brightness = brightness
+            if self._use_percent:
+                brightnessPercent = int(brightness * 100 / 255)
+                commands.append(self._prepareSinglePacketData(LedCommand.BRIGHTNESS, [brightnessPercent]))
+            else:
+                commands.append(self._prepareSinglePacketData(LedCommand.BRIGHTNESS, [brightness]))
+            new_brightness = brightness
 
         if ATTR_RGB_COLOR in kwargs:
             red, green, blue = kwargs.get(ATTR_RGB_COLOR)
@@ -273,48 +358,173 @@ class GoveeBluetoothLight(LightEntity):
                                                                0x00, 0x00, 0xFF, 0x7F]))
             else:
                 commands.append(self._prepareSinglePacketData(LedCommand.COLOR, [LedMode.MANUAL, red, green, blue]))
-        if ATTR_EFFECT in kwargs:
-            effect = kwargs.get(ATTR_EFFECT)
-            if len(effect) > 0:
-                search = EFFECT_PARSE.search(effect)
 
-                # Parse effect indexes
-                categoryIndex = int(search.group(1))
-                sceneIndex = int(search.group(2))
-                lightEffectIndex = int(search.group(3))
-                specialEffectIndex = int(search.group(4))
+            new_rgb = (red, green, blue)
+            new_effect = None
 
-                json_data = json.loads(Path(Path(__file__).parent / "jsons" / (self._model + ".json")).read_text())
-                category = json_data['data']['categories'][categoryIndex]
-                scene = category['scenes'][sceneIndex]
-                lightEffect = scene['lightEffects'][lightEffectIndex]
-                specialEffect = lightEffect['specialEffect'][specialEffectIndex]
+        if ATTR_EFFECT in kwargs and kwargs.get(ATTR_EFFECT):
+            effect = kwargs[ATTR_EFFECT]
+            scene_commands = self._scene_commands(effect)
+            if scene_commands is None:
+                _LOGGER.warning("Govee %s: unknown effect %r", self._mac, effect)
+            else:
+                commands.extend(scene_commands)
+                new_effect = effect
 
-                # Prepare packets to send big payload in separated chunks
-                for command in prepareMultiplePacketsData(0xa3,
-                                                          array.array('B', [0x02]),
-                                                          array.array('B',
-                                                                      base64.b64decode(specialEffect['scenceParam'])
-                                                                      )):
-                    commands.append(command)
+        # All packets for this command go out over a single BLE session.
+        await self._send_commands(commands)
 
-        for command in commands:
-            client = await self._connectBluetooth()
-            await client.write_gatt_char(UUID_CONTROL_CHARACTERISTIC, command, False)
+        # Only reflect new state once the writes actually succeeded.
+        self._state = True
+        self._brightness = new_brightness
+        self._rgb_color = new_rgb
+        self._effect = new_effect
+        self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs) -> None:
-        client = await self._connectBluetooth()
-        await client.write_gatt_char(UUID_CONTROL_CHARACTERISTIC,
-                                     self._prepareSinglePacketData(LedCommand.POWER, [0x0]), False)
+        await self._send_commands([self._prepareSinglePacketData(LedCommand.POWER, [0x0])])
         self._state = False
+        self.async_write_ha_state()
 
-    async def _connectBluetooth(self) -> BleakClient:
-        for i in range(3):
+    def _scene_commands(self, effect: str) -> list | None:
+        """Resolve an effect name to its chunked BLE scene packets, or None."""
+        indices = self._effect_indexes.get(effect)
+        if indices is None:
+            # Backward compatibility with the old "... [c/s/le/se]" names.
+            search = EFFECT_PARSE.search(effect)
+            if not search:
+                return None
+            indices = tuple(int(search.group(i)) for i in range(1, 5))
+
+        if self._model_json is None:
+            _LOGGER.warning("Govee %s: effect catalogue not loaded yet", self._mac)
+            return None
+
+        category_idx, scene_idx, light_idx, special_idx = indices
+        try:
+            scene = (self._model_json['data']['categories'][category_idx]
+                     ['scenes'][scene_idx])
+            light_effect = scene['lightEffects'][light_idx]
+            special_effect = light_effect['specialEffect'][special_idx]
+            param = base64.b64decode(special_effect['scenceParam'])
+        except (KeyError, IndexError, ValueError) as err:
+            _LOGGER.warning("Govee %s: bad effect data for %r: %s", self._mac, effect, err)
+            return None
+
+        packets = list(prepareMultiplePacketsData(0xa3,
+                                                  array.array('B', [0x02]),
+                                                  array.array('B', param)))
+
+        # The 0xa3 upload only loads the scene into the strip's memory; it does
+        # NOT switch the strip out of manual-color mode. The strip plays the
+        # scene only after this "activate scene" packet:
+        #   33 05 04 <sceneCodeLo> <sceneCodeHi>   (sceneCode is 2-byte little-endian)
+        # Reverse-engineered live on H617A (2026-06-29). Without it, scenes never
+        # animate; with it, every scene works. The sceneCode lives per lightEffect
+        # (falling back to the scene's own code).
+        scene_code = light_effect.get('sceneCode')
+        if scene_code is None:
+            scene_code = scene.get('sceneCode')
+        if scene_code is not None:
+            packets.append(self._prepareSinglePacketData(
+                LedCommand.COLOR,
+                [0x04, scene_code & 0xFF, (scene_code >> 8) & 0xFF]))
+        else:
+            _LOGGER.warning("Govee %s: effect %r has no sceneCode; it will upload "
+                            "but may not activate", self._mac, effect)
+
+        _LOGGER.debug("Govee %s: scene %r -> %d byte param -> %d packets (code %s)",
+                      self._mac, effect, len(param), len(packets), scene_code)
+        return packets
+
+    async def _send_commands(self, commands: list) -> None:
+        """Send all packets for one command over a single, freshly-established session.
+
+        Two hard-won constraints, both confirmed on H617A hardware behind an
+        ESPHome BLE proxy:
+
+        1. All packets of a command must ride ONE connection, and for a dynamic
+           scene the link must stay OPEN for several seconds after the upload or
+           the strip never commits it (disconnecting ~2s later discards it; once
+           committed it persists like closing the Govee app). So we keep the
+           connection open and close it later on an idle timer.
+        2. We must never *reuse* a held-open connection for the next command:
+           the strip drops idle links and the proxy keeps reporting
+           ``is_connected == True``, so write-without-response packets (which are
+           never ack'd) vanish silently. So every command establishes a fresh
+           connection, closing any prior held one first.
+        """
+        async with self._command_lock:
+            self._cancel_idle_disconnect()
+            await self._disconnect()  # never write to a possibly-stale held link
+
+            last_err: Exception | None = None
+            for attempt in range(1, MAX_COMMAND_ATTEMPTS + 1):
+                try:
+                    self._client = await self._connect()
+                    _LOGGER.debug("Govee %s: connected=%s, sending %d packets (%d bytes total)",
+                                  self._mac, self._client.is_connected, len(commands),
+                                  sum(len(c) for c in commands))
+                    for idx, command in enumerate(commands):
+                        await self._client.write_gatt_char(UUID_CONTROL_CHARACTERISTIC, command, False)
+                        _LOGGER.debug("Govee %s: wrote packet %d/%d (%d bytes)",
+                                      self._mac, idx + 1, len(commands), len(command))
+                    # Leave the link open so the strip can commit, then auto-close.
+                    self._schedule_idle_disconnect()
+                    return
+                except Exception as err:  # noqa: BLE001 - BLE stacks raise a zoo of errors
+                    last_err = err
+                    _LOGGER.warning("Govee %s: BLE command failed (attempt %d/%d): %s",
+                                    self._mac, attempt, MAX_COMMAND_ATTEMPTS, err)
+                    await self._disconnect()
+            raise HomeAssistantError(
+                f"Govee {self._mac}: BLE command failed after {MAX_COMMAND_ATTEMPTS} attempts: {last_err}")
+
+    async def _connect(self) -> BleakClient:
+        """Establish a fresh BLE connection to the strip."""
+        # Always re-fetch the device handle; a cached one goes stale across
+        # adapter changes and re-advertisements.
+        ble_device = bluetooth.async_ble_device_from_address(self.hass, self._mac.upper(), True)
+        if ble_device is None:
+            raise HomeAssistantError(f"Govee {self._mac} is not visible to Home Assistant's Bluetooth")
+        self._ble_device = ble_device
+
+        # Serialize connection establishment across all strips on the shared radio.
+        async with _CONNECT_LOCK:
+            client = await bleak_retry_connector.establish_connection(
+                BleakClient, ble_device, self.unique_id,
+            )
+            _LOGGER.debug("Govee %s: established connection to %s (connectable device)",
+                          self._mac, ble_device.address)
+            return client
+
+    def _schedule_idle_disconnect(self) -> None:
+        """(Re)arm the timer that closes the held-open link after an idle window."""
+        self._cancel_idle_disconnect()
+        self._idle_disconnect_cancel = async_call_later(
+            self.hass, IDLE_DISCONNECT_SECONDS, self._async_idle_disconnect)
+
+    def _cancel_idle_disconnect(self) -> None:
+        if self._idle_disconnect_cancel is not None:
+            self._idle_disconnect_cancel()
+            self._idle_disconnect_cancel = None
+
+    async def _async_idle_disconnect(self, _now) -> None:
+        self._idle_disconnect_cancel = None
+        async with self._command_lock:
+            # If a command re-armed the timer while we waited for the lock, a newer
+            # connection is in use — don't tear it down.
+            if self._idle_disconnect_cancel is None:
+                await self._disconnect()
+
+    async def _disconnect(self) -> None:
+        client = self._client
+        self._client = None
+        if client is not None:
             try:
-                client = await bleak_retry_connector.establish_connection(BleakClient, self._ble_device, self.unique_id)
-                return client
-            except:
-                continue
+                await client.disconnect()
+            except Exception:  # noqa: BLE001 - best-effort teardown
+                pass
 
     def _prepareSinglePacketData(self, cmd, payload):
         if not isinstance(cmd, int):

--- a/custom_components/govee-ble-lights/light.py
+++ b/custom_components/govee-ble-lights/light.py
@@ -16,18 +16,55 @@ from homeassistant.components.light import (ATTR_BRIGHTNESS, ATTR_RGB_COLOR, ATT
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_platform
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.storage import Store
+
+import voluptuous as vol
 
 from .const import DOMAIN
 from pathlib import Path
 import json
 from .govee_utils import prepareMultiplePacketsData
+from .govee_scene_speed import apply_scene_speed
 import base64
+from homeassistant.helpers.storage import Store
 from . import Hub
 
 _LOGGER = logging.getLogger(__name__)
+
+# Per-scene speed presets, shared by all strips and persisted to HA storage so they
+# survive restarts and HACS updates. Maps an effect's display name to a chosen speed
+# level (int) or the string "auto" (follow Govee's default) / "off" (scene baseline).
+# A scene absent from the map is treated as "auto".
+_SCENE_SPEED_STORE_KEY = "govee_ble_lights_scene_speeds"
+_SCENE_SPEED_VERSION = 1
+_scene_speed_presets: dict[str, object] = {}
+_scene_speed_store: Store | None = None
+_scene_speed_loaded = False
+_scene_speed_lock = asyncio.Lock()
+
+
+async def _ensure_scene_presets(hass) -> None:
+    """Load the shared scene-speed presets once (idempotent across all entities)."""
+    global _scene_speed_store, _scene_speed_loaded
+    async with _scene_speed_lock:
+        if _scene_speed_loaded:
+            return
+        _scene_speed_store = Store(hass, _SCENE_SPEED_VERSION, _SCENE_SPEED_STORE_KEY)
+        try:
+            data = await _scene_speed_store.async_load()
+            if isinstance(data, dict):
+                _scene_speed_presets.update(data)
+        except Exception as err:  # noqa: BLE001 - bad store shouldn't break the light
+            _LOGGER.warning("Govee: could not load scene-speed presets: %s", err)
+        _scene_speed_loaded = True
+
+
+async def _save_scene_presets() -> None:
+    if _scene_speed_store is not None:
+        await _scene_speed_store.async_save(dict(_scene_speed_presets))
 
 UUID_CONTROL_CHARACTERISTIC = '00010203-0405-0607-0809-0a0b0c0d2b11'
 EFFECT_PARSE = re.compile(r"\[(\d+)/(\d+)/(\d+)/(\d+)]")
@@ -83,6 +120,25 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
     elif hub.address is not None:
         ble_device = bluetooth.async_ble_device_from_address(hass, hub.address.upper(), False)
         async_add_entities([GoveeBluetoothLight(hub, ble_device, config_entry)])
+
+        platform = entity_platform.async_get_current_platform()
+
+        # This strip's current speed: an int level (0 = liveliest; higher = calmer,
+        # varies per scene), "auto" (follow the scene's saved/Govee default), or
+        # "off" (scene baseline). Re-applies the current effect immediately.
+        speed_value = vol.Any("auto", "off", vol.Coerce(int))
+        platform.async_register_entity_service(
+            "set_speed",
+            {vol.Required("speed_index"): speed_value},
+            "async_set_speed",
+        )
+        # Save (or clear) the per-scene speed preset for the current effect. An int
+        # pins that scene's speed everywhere; "auto" reverts it to Govee's default.
+        platform.async_register_entity_service(
+            "set_scene_speed",
+            {vol.Required("speed_index"): vol.Any("auto", "off", vol.Coerce(int))},
+            "async_set_scene_speed",
+        )
 
 
 class GoveeAPILight(LightEntity, dict):
@@ -226,6 +282,9 @@ class GoveeBluetoothLight(RestoreEntity, LightEntity):
         self._effect_indexes: dict[str, tuple[int, int, int, int]] = {}
         self._model_json: dict | None = None
         self._attr_effect_list = []
+        # This strip's current speed setting: "auto" (follow the scene's saved/Govee
+        # default), an int level, or "off" (scene baseline, no speed rewrite).
+        self._speed_index: object = "auto"
 
     async def async_added_to_hass(self) -> None:
         """Restore prior state and load the effect catalogue (off the event loop)."""
@@ -238,6 +297,11 @@ class GoveeBluetoothLight(RestoreEntity, LightEntity):
             rgb = last_state.attributes.get("rgb_color")
             self._rgb_color = tuple(rgb) if rgb else None
             self._effect = last_state.attributes.get("effect")
+            restored_speed = last_state.attributes.get("speed_index")
+            if restored_speed is not None:
+                self._speed_index = restored_speed
+
+        await _ensure_scene_presets(self.hass)
 
         await self._async_load_effects()
 
@@ -405,11 +469,28 @@ class GoveeBluetoothLight(RestoreEntity, LightEntity):
             scene = (self._model_json['data']['categories'][category_idx]
                      ['scenes'][scene_idx])
             light_effect = scene['lightEffects'][light_idx]
-            special_effect = light_effect['specialEffect'][special_idx]
+            specials = light_effect['specialEffect']
+            # Prefer the variant whose supportSku matches this model: its blob is
+            # the same bytes, but it carries the per-model speedInfo we apply below.
+            special_effect = next(
+                (se for se in specials
+                 if self._model in (se.get('supportSku') or [])),
+                specials[special_idx])
             param = base64.b64decode(special_effect['scenceParam'])
         except (KeyError, IndexError, ValueError) as err:
             _LOGGER.warning("Govee %s: bad effect data for %r: %s", self._mac, effect, err)
             return None
+
+        # Apply the resolved speed level by rewriting the speed bytes in the blob the
+        # way the Govee app does. resolve returns "off" (upload baseline untouched),
+        # "auto" (use Govee's per-scene defaultIndex), or an int level. See
+        # govee_scene_speed for the byte-level details.
+        speed_info = special_effect.get('speedInfo') or {}
+        if speed_info.get('supSpeed') and speed_info.get('config'):
+            level = self._resolve_speed(effect)
+            if level != "off":
+                override = None if level == "auto" else level
+                param = apply_scene_speed(param, speed_info['config'], override)
 
         packets = list(prepareMultiplePacketsData(0xa3,
                                                   array.array('B', [0x02]),
@@ -525,6 +606,55 @@ class GoveeBluetoothLight(RestoreEntity, LightEntity):
                 await client.disconnect()
             except Exception:  # noqa: BLE001 - best-effort teardown
                 pass
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Surface the speed settings: this strip's level, the current scene's saved
+        preset, and the level that actually resolves for the current effect."""
+        scene_preset = (_scene_speed_presets.get(self._effect, "auto")
+                        if self._effect else None)
+        return {
+            "speed_index": self._speed_index,
+            "scene_speed_preset": scene_preset,
+            "resolved_speed": self._resolve_speed(self._effect) if self._effect else None,
+        }
+
+    def _resolve_speed(self, effect: str | None) -> object:
+        """Resolve the effective speed for an effect: an int level, "auto" (Govee
+        default), or "off" (baseline). Precedence: this strip's pinned level >
+        the scene's saved preset > "auto"."""
+        if isinstance(self._speed_index, int) or self._speed_index == "off":
+            return self._speed_index
+        # strip is on "auto" -> defer to the scene's saved preset (default "auto")
+        if effect is None:
+            return "auto"
+        return _scene_speed_presets.get(effect, "auto")
+
+    async def async_set_speed(self, speed_index) -> None:
+        """Set THIS strip's current speed and re-apply the current effect now."""
+        self._speed_index = speed_index
+        if self._effect:
+            await self.async_turn_on(effect=self._effect)
+        self.async_write_ha_state()
+
+    async def async_set_scene_speed(self, speed_index) -> None:
+        """Save (or clear) the current scene's speed preset for all strips.
+
+        An int pins that scene's speed; "auto" removes the preset (Govee default).
+        The preset only takes visible effect where a strip's own speed is "auto".
+        """
+        if self._effect is None:
+            _LOGGER.warning("Govee %s: set_scene_speed with no active effect", self._mac)
+            return
+        if speed_index == "auto":
+            _scene_speed_presets.pop(self._effect, None)
+        else:
+            _scene_speed_presets[self._effect] = speed_index
+        await _save_scene_presets()
+        # Re-apply here so the change is visible immediately on this strip too.
+        if self._speed_index == "auto":
+            await self.async_turn_on(effect=self._effect)
+        self.async_write_ha_state()
 
     def _prepareSinglePacketData(self, cmd, payload):
         if not isinstance(cmd, int):

--- a/custom_components/govee-ble-lights/light.py
+++ b/custom_components/govee-ble-lights/light.py
@@ -74,6 +74,13 @@ PERCENT_MODELS = ['H617A']
 # Number of BLE write attempts before a command is reported as failed.
 MAX_COMMAND_ATTEMPTS = 3
 
+# When the strip only accepts write-without-response, those writes are never
+# ACKed: behind a BLE proxy at range a dropped packet vanishes silently and the
+# scene upload never lands (the strip just replays its last frame). Pace the
+# chunked packets so a distant proxy doesn't overrun and drop them. Acknowledged
+# writes (Write Request) self-pace, so this only applies to the fallback path.
+INTER_PACKET_DELAY = 0.02  # seconds
+
 # A dynamic scene needs the BLE link held open for a few seconds after upload to
 # commit (then it persists, like closing the Govee app). We keep the connection
 # open after every command and close it only after this idle window, so we don't
@@ -543,13 +550,27 @@ class GoveeBluetoothLight(RestoreEntity, LightEntity):
             for attempt in range(1, MAX_COMMAND_ATTEMPTS + 1):
                 try:
                     self._client = await self._connect()
-                    _LOGGER.debug("Govee %s: connected=%s, sending %d packets (%d bytes total)",
-                                  self._mac, self._client.is_connected, len(commands),
+                    # Prefer acknowledged writes (Write Request) when the strip
+                    # offers them: at range a write-without-response packet is
+                    # dropped silently, so a scene upload never lands and the
+                    # strip replays its old frame. An ACKed write raises on a
+                    # dropped packet, so the retry loop below actually re-sends
+                    # instead of silently no-op'ing. Fall back to write-without-
+                    # response (paced) when the characteristic can't do requests.
+                    char = self._client.services.get_characteristic(UUID_CONTROL_CHARACTERISTIC)
+                    use_response = char is not None and "write" in char.properties
+                    target = char if char is not None else UUID_CONTROL_CHARACTERISTIC
+                    _LOGGER.debug("Govee %s: connected=%s, write_response=%s, sending %d packets (%d bytes total)",
+                                  self._mac, self._client.is_connected, use_response, len(commands),
                                   sum(len(c) for c in commands))
                     for idx, command in enumerate(commands):
-                        await self._client.write_gatt_char(UUID_CONTROL_CHARACTERISTIC, command, False)
+                        await self._client.write_gatt_char(target, command, response=use_response)
                         _LOGGER.debug("Govee %s: wrote packet %d/%d (%d bytes)",
                                       self._mac, idx + 1, len(commands), len(command))
+                        # Pace the unacknowledged fallback so a distant proxy
+                        # doesn't overrun; ACKed writes already self-pace.
+                        if not use_response and idx + 1 < len(commands):
+                            await asyncio.sleep(INTER_PACKET_DELAY)
                     # Leave the link open so the strip can commit, then auto-close.
                     self._schedule_idle_disconnect()
                     return

--- a/custom_components/govee-ble-lights/manifest.json
+++ b/custom_components/govee-ble-lights/manifest.json
@@ -17,5 +17,5 @@
     "documentation": "https://github.com/Beshelmek/govee_ble_lights",
     "config_flow": true,
     "iot_class": "local_polling",
-    "version": "0.1.1"
+    "version": "0.1.2"
 }

--- a/custom_components/govee-ble-lights/manifest.json
+++ b/custom_components/govee-ble-lights/manifest.json
@@ -17,5 +17,5 @@
     "documentation": "https://github.com/Beshelmek/govee_ble_lights",
     "config_flow": true,
     "iot_class": "local_polling",
-    "version": "0.1.2"
+    "version": "0.1.3"
 }

--- a/custom_components/govee-ble-lights/manifest.json
+++ b/custom_components/govee-ble-lights/manifest.json
@@ -17,5 +17,5 @@
     "documentation": "https://github.com/Beshelmek/govee_ble_lights",
     "config_flow": true,
     "iot_class": "local_polling",
-    "version": "0.1.4"
+    "version": "0.1.5"
 }

--- a/custom_components/govee-ble-lights/manifest.json
+++ b/custom_components/govee-ble-lights/manifest.json
@@ -17,5 +17,5 @@
     "documentation": "https://github.com/Beshelmek/govee_ble_lights",
     "config_flow": true,
     "iot_class": "local_polling",
-    "version": "0.1.3"
+    "version": "0.1.4"
 }

--- a/custom_components/govee-ble-lights/services.yaml
+++ b/custom_components/govee-ble-lights/services.yaml
@@ -1,0 +1,44 @@
+set_speed:
+  name: Set strip speed
+  description: >-
+    Set this strip's scene speed. Applies immediately to the current effect and
+    persists across restarts. Speed "feel" is per-scene: the byte's direction and
+    range depend on the scene's colour type, so the same level looks different
+    across scenes.
+  target:
+    entity:
+      integration: govee-ble-lights
+      domain: light
+  fields:
+    speed_index:
+      name: Speed
+      description: >-
+        An integer level (0 = liveliest; higher = calmer, range varies per
+        scene), "auto" (follow the scene's saved/Govee-recommended speed), or
+        "off" (upload the scene baseline untouched).
+      required: true
+      example: "auto"
+      selector:
+        text:
+
+set_scene_speed:
+  name: Set scene speed preset
+  description: >-
+    Save (or clear) a per-scene speed preset for this strip's current effect. An
+    integer pins that scene's speed for every strip that's on "auto"; "auto"
+    clears the preset back to Govee's default. Presets persist to Home Assistant
+    storage.
+  target:
+    entity:
+      integration: govee-ble-lights
+      domain: light
+  fields:
+    speed_index:
+      name: Speed
+      description: >-
+        An integer to pin this scene's speed (0 = liveliest; higher = calmer),
+        or "auto" to clear the preset back to Govee's per-scene default.
+      required: true
+      example: "auto"
+      selector:
+        text:


### PR DESCRIPTION
Adds working **dynamic scene** support for the **H617A** RGBIC strip over local BLE, plus transport hardening that benefits any BLE model.

### H617A dynamic scenes
On the H617A, uploading a scene's `scenceParam` via the `0xa3` multi-packet protocol only *loads* the scene into the strip — it does not switch it out of manual-colour mode, so the scene never animates. The strip starts playing only after an explicit activate packet:

```
33 05 04 <sceneCodeLo> <sceneCodeHi>   # sceneCode is 2-byte little-endian, per lightEffect
```

So setting a scene is two steps over one BLE session: upload the `0xa3` `scenceParam`, then send the activate packet. Reverse-engineered on H617A hardware; ~25 scenes across all nine categories animate from the standard effect dropdown. The bundled `jsons/H617A.json` is payload-identical to the existing `H617C.json`.

### Scene speed
There is no separate BLE "speed" command — the app rewrites timing bytes inside the `scenceParam` blob before upload. This reproduces that (`govee_scene_speed.py`), exposed as two entity services: `set_speed` (per-strip level) and `set_scene_speed` (per-effect preset, persisted). An unrecognised blob is uploaded untouched.

### BLE transport hardening (model-agnostic)
- All packets of a command ride one freshly-established connection; the link is held open briefly so a scene upload commits, then closed on an idle timer.
- A held connection is never reused — an idle strip behind an ESPHome BLE proxy keeps reporting `is_connected == True` while silently dropping write-without-response packets.
- Prefer acknowledged writes (Write Request) when the characteristic supports them, so a packet dropped at range raises and retries instead of vanishing; paced write-without-response fallback otherwise.
- Per-entity command lock + module-level connect lock; `available` reflects the BT stack; state survives restarts via `RestoreEntity`; effect names rendered as `Category - Scene`.
- `config_flow` no longer runs a blocking `iterdir()` on the event loop.

Non-breaking for other models: the activate step is gated on a per-effect `sceneCode`, and the speed rewrite no-ops on unrecognised blobs. Tested on three H617A strips.